### PR TITLE
add Eltako FR62-230V

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -5541,6 +5541,7 @@ eltako:
               state_topic: "f6"
               state_template: >-
                 {% if value_json._RAW_DATA_.split(":")[0]=="70" %}on{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}off{% endif %}
+   fr62: *tf61l
    fud14: &fud14
       device_config:
          - rorg: "0xA5"


### PR DESCRIPTION
Adds support for the Eltako FR62-230V

The messages seem to be the same as the TF61L.
I'm not using the FSR14 because the button to enable feedback telegrams is needed.