### PR TITLE
Suppport Afriso FR sensor

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -5769,6 +5769,39 @@ eltako:
               payload_on: "1"
               payload_off: "0"
 
+# Mapping for Afriso devices
+afriso:
+   # https://www.afriso.com/en/PM/Domestic-technology/Equipment-for-surface-heating-and-cooling-systems/Room-temperature-sensor-FT-FTF-wireless
+   ft:
+      device_config:
+        - rorg: "0xA5"
+          func: "0x10"
+          type: "0x03"
+          command: ""
+          channel: ""
+          log_learn: ""
+          direction: ""
+          answer: ""
+      entities:
+         - component: sensor
+           name: "setpoint"
+           config:
+              state_topic: "a5"
+              value_template: >-
+                {{ ((value_json.SP | float(default=0)) / 255.0 * 22.0 + 8.0) | round(1) }}
+              device_class: "temperature"
+              state_class: "measurement"
+              unit_of_measurement: "°C"
+         - component: sensor
+           name: "temp"
+           config:
+              state_topic: "a5"
+              value_template: >-
+                {{ value_json.TMP | float(default=0) | round(1) }}
+              device_class: "temperature"
+              state_class: "measurement"
+              unit_of_measurement: "°C"
+
 # Below are mappings common to all EEPs
 common:
    rssi:


### PR DESCRIPTION
Adds support for the Afriso FT sensor.

The scaling of the setpoint is according to the technical details shown on https://www.afriso.com/en/PM/Domestic-technology/Equipment-for-surface-heating-and-cooling-systems/Room-temperature-sensor-FT-FTF-wireless (adjustment range 8-30 degree Celsius)