### PR TITLE
D2-01-01 state fix

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -15,9 +15,14 @@
               name: "switch"
               config:
                  state_topic: "CMD4"
-                 state_on: "100"
-                 state_off: "0"
-                 value_template: "{{ value_json.OV }}"
+                 value_template: >-
+                    {% if value_json.OV == 0 %}
+                        OFF
+                    {% elif value_json.OV >= 1 and value_json.OV <= 100 %}
+                        ON
+                    {% else %}
+                        None
+                    {% endif %}
                  command_topic: "req"
                  payload_on: >
                    {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}

--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -21,7 +21,6 @@
                     {% elif value_json.OV >= 1 and value_json.OV <= 100 %}
                         ON
                     {% else %}
-                        None
                     {% endif %}
                  command_topic: "req"
                  payload_on: >


### PR DESCRIPTION
Original message : https://community.home-assistant.io/t/enocean-with-ha-enoceanmqtt/491606/98

Hallo! I finally managed it to get my DALI dimming actuators working by using a virtual rocker combined with a template. The only thing I am missing is a correct state of the actuator. It’s always “off”

When I look at the MQTT-Explorer, I can find the packages of the DALI dimming actuator.
{"_DATE_": "2025-09-17T21:11:25.026979", "_RAW_DATA_": "04:60:C6:00", "PF": 0, "PFD": 0, "OC": 0, "EL": 3, "IO": 0, "LC": 1, "OV": 70}
The OV-value represents the dimming value. It is between 0 and 100(%) (in this case 70) but the state of the actuator itselves is always “off”.
What can I do to get a state: “on” for 1 to 100 percent value an a state “off” for 0 percent.

I already tried it with a template, but failed. Any Ideas?

Best, Stefan