### PR TITLE
Fix inconsistent indentation

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -3,5846 +3,5846 @@
 
 # Mapping of EEPs to Home Assistant Entities
 0xD2:
-   0x01:
-      0x01:
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "switch"
-              name: "switch"
-              config:
-                 state_topic: "CMD4"
-                 value_template: >-
-                    {% if value_json.OV == 0 %}
-                        OFF
-                    {% elif value_json.OV >= 1 and value_json.OV <= 100 %}
-                        ON
-                    {% else %}
-                    {% endif %}
-                 command_topic: "req"
-                 payload_on: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
-                 payload_off: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
-                 device_class: outlet
-            - component: "button"
-              name: "query_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-            - component: binary_sensor
-              name: "LC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-      0x08:
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "switch"
-              name: "switch"
-              config:
-                 state_topic: "CMD4"
-                 state_on: "100"
-                 state_off: "0"
-                 value_template: "{{ value_json.OV }}"
-                 command_topic: "req"
-                 payload_on: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
-                 payload_off: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
-                 device_class: outlet
-            - component: "sensor"
-              name: "energy"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "total_increasing"
-                 device_class: "energy"
-                 unit_of_measurement: "Wh"
-                 value_template: >-
-                   {% if value_json.UN == 0 %}
-                     {{ (value_json.MV|int / 3600)|int }}
-                   {% elif value_json.UN == 1 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 2 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "sensor"
-              name: "power"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "measurement"
-                 device_class: "power"
-                 unit_of_measurement: "W"
-                 value_template: >-
-                   {% if value_json.UN == 3 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 4 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "button"
-              name: "query_energy"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"0","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_power"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"1","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-            - component: "switch"
-              name: "reset_meas"
-              config:
-                 command_topic: "__trash"
-                 icon: "mdi:numeric-0-circle-outline"
-            - component: "select"
-              name: "meas_type"
-              config:
-                 options:
-                    - "Query only - Energy in Ws"
-                    - "Query only - Energy in Wh"
-                    - "Query only - Energy in KWh"
-                    - "Query only - Power in W"
-                    - "Query only - Power in KW"
-                    - "Query & Auto - Energy in Ws"
-                    - "Query & Auto - Energy in Wh"
-                    - "Query & Auto - Energy in KWh"
-                    - "Query & Auto - Power in W"
-                    - "Query & Auto - Power in KW"
-                 command_topic: "__trash"
-                 icon: "mdi:tune"
-            - component: "number"
-              name: "meas_MAT"
-              config:
-                 command_topic: "__trash"
-                 min: "10"
-                 max: "2550"
-                 step: "10"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MIT"
-              config:
-                 command_topic: "__trash"
-                 min: "1"
-                 max: "255"
-                 step: "1"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MD"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "4095"
-                 step: "1"
-                 mode: "box"
-                 icon: "mdi:equalizer"
-            - component: "button"
-              name: "set_meas"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('meas_type',ignorecase=True) %}
-                       {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
-                       {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
-                       {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
-                       {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
-                       {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
-                       {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
-                       {% else %}{% set ns.UN = 3 %}
-                       {% endif %}
-                     {% elif entity is search('reset_meas',ignorecase=True) %}
-                       {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
-                     {% elif entity is search('meas_mat',ignorecase=True) %}
-                       {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
-                     {% elif entity is search('meas_mit',ignorecase=True) %}
-                       {% set ns.MIT = states(entity)|int(default=1) %}
-                     {% elif entity is search('meas_md',ignorecase=True) %}
-                       {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
-                       {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
-                     {% endif %}
-                   {% endfor %}
-                   {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
-                 icon: "mdi:download"
-            - component: binary_sensor
-              name: "OC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.OC == 1 %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "LC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-      0x09:
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "switch"
-              name: "switch"
-              config:
-                 state_topic: "CMD4"
-                 state_on: "100"
-                 state_off: "0"
-                 value_template: "{{ value_json.OV }}"
-                 command_topic: "req"
-                 payload_on: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
-                 payload_off: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
-                 device_class: outlet
-            - component: "sensor"
-              name: "energy"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "total_increasing"
-                 device_class: "energy"
-                 unit_of_measurement: "Wh"
-                 value_template: >-
-                   {% if value_json.UN == 0 %}
-                     {{ (value_json.MV|int / 3600)|int }}
-                   {% elif value_json.UN == 1 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 2 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "sensor"
-              name: "power"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "measurement"
-                 device_class: "power"
-                 unit_of_measurement: "W"
-                 value_template: >-
-                   {% if value_json.UN == 3 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 4 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "button"
-              name: "query_energy"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"0","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_power"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"1","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-            - component: "switch"
-              name: "reset_meas"
-              config:
-                 command_topic: "__trash"
-                 icon: "mdi:numeric-0-circle-outline"
-            - component: "select"
-              name: "meas_type"
-              config:
-                 options:
-                    - "Query only - Energy in Ws"
-                    - "Query only - Energy in Wh"
-                    - "Query only - Energy in KWh"
-                    - "Query only - Power in W"
-                    - "Query only - Power in KW"
-                    - "Query & Auto - Energy in Ws"
-                    - "Query & Auto - Energy in Wh"
-                    - "Query & Auto - Energy in KWh"
-                    - "Query & Auto - Power in W"
-                    - "Query & Auto - Power in KW"
-                 command_topic: "__trash"
-                 icon: "mdi:tune"
-            - component: "number"
-              name: "meas_MAT"
-              config:
-                 command_topic: "__trash"
-                 min: "10"
-                 max: "2550"
-                 step: "10"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MIT"
-              config:
-                 command_topic: "__trash"
-                 min: "1"
-                 max: "255"
-                 step: "1"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MD"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "4095"
-                 step: "1"
-                 mode: "box"
-                 icon: "mdi:equalizer"
-            - component: "button"
-              name: "set_meas"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('meas_type',ignorecase=True) %}
-                       {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
-                       {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
-                       {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
-                       {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
-                       {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
-                       {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
-                       {% else %}{% set ns.UN = 3 %}
-                       {% endif %}
-                     {% elif entity is search('reset_meas',ignorecase=True) %}
-                       {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
-                     {% elif entity is search('meas_mat',ignorecase=True) %}
-                       {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
-                     {% elif entity is search('meas_mit',ignorecase=True) %}
-                       {% set ns.MIT = states(entity)|int(default=1) %}
-                     {% elif entity is search('meas_md',ignorecase=True) %}
-                       {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
-                       {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
-                     {% endif %}
-                   {% endfor %}
-                   {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
-                 icon: "mdi:download"
-            - component: binary_sensor
-              name: "OC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.OC == 1 %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "LC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-      0x0A:
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "switch"
-              name: "switch"
-              config:
-                 state_topic: "CMD4"
-                 state_on: "100"
-                 state_off: "0"
-                 value_template: "{{ value_json.OV }}"
-                 command_topic: "req"
-                 payload_on: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
-                 payload_off: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
-                 device_class: outlet
-            - component: "button"
-              name: "query_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-            - component: binary_sensor
-              name: "PF"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.PF == 1 %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "PFD"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.PFD == 1 %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "LC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-      0x0B:
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "switch"
-              name: "switch"
-              config:
-                 state_topic: "CMD4"
-                 state_on: "100"
-                 state_off: "0"
-                 value_template: "{{ value_json.OV }}"
-                 command_topic: "req"
-                 payload_on: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
-                 payload_off: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
-                 device_class: outlet
-            - component: "sensor"
-              name: "energy"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "total_increasing"
-                 device_class: "energy"
-                 unit_of_measurement: "Wh"
-                 value_template: >-
-                   {% if value_json.UN == 0 %}
-                     {{ (value_json.MV|int / 3600)|int }}
-                   {% elif value_json.UN == 1 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 2 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "sensor"
-              name: "power"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "measurement"
-                 device_class: "power"
-                 unit_of_measurement: "W"
-                 value_template: >-
-                   {% if value_json.UN == 3 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 4 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "button"
-              name: "query_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_energy"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"0","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_power"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"1","IO":"30","send":"clear"}
-            - component: "switch"
-              name: "reset_meas"
-              config:
-                 command_topic: "__trash"
-                 icon: "mdi:numeric-0-circle-outline"
-            - component: "select"
-              name: "meas_type"
-              config:
-                 options:
-                    - "Query only - Energy in Ws"
-                    - "Query only - Energy in Wh"
-                    - "Query only - Energy in KWh"
-                    - "Query only - Power in W"
-                    - "Query only - Power in KW"
-                    - "Query & Auto - Energy in Ws"
-                    - "Query & Auto - Energy in Wh"
-                    - "Query & Auto - Energy in KWh"
-                    - "Query & Auto - Power in W"
-                    - "Query & Auto - Power in KW"
-                 command_topic: "__trash"
-                 icon: "mdi:tune"
-            - component: "number"
-              name: "meas_MAT"
-              config:
-                 command_topic: "__trash"
-                 min: "10"
-                 max: "2550"
-                 step: "10"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MIT"
-              config:
-                 command_topic: "__trash"
-                 min: "1"
-                 max: "255"
-                 step: "1"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MD"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "4095"
-                 step: "1"
-                 mode: "box"
-                 icon: "mdi:equalizer"
-            - component: "button"
-              name: "set_meas"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('meas_type',ignorecase=True) %}
-                       {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
-                       {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
-                       {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
-                       {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
-                       {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
-                       {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
-                       {% else %}{% set ns.UN = 3 %}
-                       {% endif %}
-                     {% elif entity is search('reset_meas',ignorecase=True) %}
-                       {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
-                     {% elif entity is search('meas_mat',ignorecase=True) %}
-                       {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
-                     {% elif entity is search('meas_mit',ignorecase=True) %}
-                       {% set ns.MIT = states(entity)|int(default=1) %}
-                     {% elif entity is search('meas_md',ignorecase=True) %}
-                       {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
-                       {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
-                     {% endif %}
-                   {% endfor %}
-                   {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
-                 icon: "mdi:download"
-            - component: binary_sensor
-              name: "PF"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.PF == 1 %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "PFD"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.PFD == 1 %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "LC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-      0x0C:
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "select"
-              name: "mode"
-              config:
-                 options:
-                    - "Off"
-                    - "Comfort"
-                    - "Eco"
-                    - "Anti-freeze"
-                    - "Comfort-1"
-                    - "Comfort-2"
-                 command_topic: "req"
-                 command_template: >-
-                   {% set modes = {"Off": "0", "Comfort": "1", "Eco": "2", "Anti-freeze": "3", "Comfort-1": "4", "Comfort-2": "5"} %}
-                   {"CMD":"8","PM":"{{modes[value]}}","send":"clear"}
-                 state_topic: "CMD10"
-                 value_template: >-
-                   {% set modes = {0: "Off", 1: "Comfort", 2: "Eco", 3: "Anti-freeze", 4: "Comfort-1", 5: "Comfort-2"} %}
-                   {{modes[value_json.PM]}}
-                 icon: "mdi:radiator"
-            - component: "sensor"
-              name: "energy"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "total_increasing"
-                 device_class: "energy"
-                 unit_of_measurement: "Wh"
-                 value_template: >-
-                   {% if value_json.UN == 0 %}
-                     {{ (value_json.MV|int / 3600)|int }}
-                   {% elif value_json.UN == 1 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 2 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "sensor"
-              name: "power"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "measurement"
-                 device_class: "power"
-                 unit_of_measurement: "W"
-                 value_template: >-
-                   {% if value_json.UN == 3 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 4 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "button"
-              name: "query_mode"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"9","send":"clear"}
-            - component: "button"
-              name: "query_energy"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"0","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_power"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"1","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-            - component: "switch"
-              name: "reset_meas"
-              config:
-                 command_topic: "__trash"
-                 icon: "mdi:numeric-0-circle-outline"
-            - component: "select"
-              name: "meas_type"
-              config:
-                 options:
-                    - "Query only - Energy in Ws"
-                    - "Query only - Energy in Wh"
-                    - "Query only - Energy in KWh"
-                    - "Query only - Power in W"
-                    - "Query only - Power in KW"
-                    - "Query & Auto - Energy in Ws"
-                    - "Query & Auto - Energy in Wh"
-                    - "Query & Auto - Energy in KWh"
-                    - "Query & Auto - Power in W"
-                    - "Query & Auto - Power in KW"
-                 command_topic: "__trash"
-                 icon: "mdi:tune"
-            - component: "number"
-              name: "meas_MAT"
-              config:
-                 command_topic: "__trash"
-                 min: "10"
-                 max: "2550"
-                 step: "10"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MIT"
-              config:
-                 command_topic: "__trash"
-                 min: "1"
-                 max: "255"
-                 step: "1"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MD"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "4095"
-                 step: "1"
-                 mode: "box"
-                 icon: "mdi:equalizer"
-            - component: "button"
-              name: "set_meas"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('meas_type',ignorecase=True) %}
-                       {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
-                       {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
-                       {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
-                       {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
-                       {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
-                       {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
-                       {% else %}{% set ns.UN = 3 %}
-                       {% endif %}
-                     {% elif entity is search('reset_meas',ignorecase=True) %}
-                       {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
-                     {% elif entity is search('meas_mat',ignorecase=True) %}
-                       {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
-                     {% elif entity is search('meas_mit',ignorecase=True) %}
-                       {% set ns.MIT = states(entity)|int(default=1) %}
-                     {% elif entity is search('meas_md',ignorecase=True) %}
-                       {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
-                       {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
-                     {% endif %}
-                   {% endfor %}
-                   {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
-                 icon: "mdi:download"
-            - component: binary_sensor
-              name: "OC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.OC == 1 %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "LC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-      0x0D:
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "switch"
-              name: "switch"
-              config:
-                 state_topic: "CMD4"
-                 state_on: "100"
-                 state_off: "0"
-                 value_template: "{{ value_json.OV }}"
-                 command_topic: "req"
-                 payload_on: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
-                 payload_off: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
-                 device_class: outlet
-            - component: "button"
-              name: "query_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-            - component: binary_sensor
-              name: "LC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-      0x0E:
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "switch"
-              name: "switch"
-              config:
-                 state_topic: "CMD4"
-                 state_on: "100"
-                 state_off: "0"
-                 value_template: "{{ value_json.OV }}"
-                 command_topic: "req"
-                 payload_on: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
-                 payload_off: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
-                 device_class: outlet
-            - component: "sensor"
-              name: "energy"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "total_increasing"
-                 device_class: "energy"
-                 unit_of_measurement: "Wh"
-                 value_template: >-
-                   {% if value_json.UN == 0 %}
-                     {{ (value_json.MV|int / 3600)|int }}
-                   {% elif value_json.UN == 1 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 2 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "sensor"
-              name: "power"
-              config:
-                 state_topic: "CMD7"
-                 state_class: "measurement"
-                 device_class: "power"
-                 unit_of_measurement: "W"
-                 value_template: >-
-                   {% if value_json.UN == 3 %}
-                     {{ value_json.MV }}
-                   {% elif value_json.UN == 4 %}
-                     {{ value_json.MV|int * 1000 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-            - component: "button"
-              name: "query_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_energy"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"0","IO":"30","send":"clear"}
-            - component: "button"
-              name: "query_power"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"6","qu":"1","IO":"30","send":"clear"}
-            - component: "switch"
-              name: "reset_meas"
-              config:
-                 command_topic: "__trash"
-                 icon: "mdi:numeric-0-circle-outline"
-            - component: "select"
-              name: "meas_type"
-              config:
-                 options:
-                    - "Query only - Energy in Ws"
-                    - "Query only - Energy in Wh"
-                    - "Query only - Energy in KWh"
-                    - "Query only - Power in W"
-                    - "Query only - Power in KW"
-                    - "Query & Auto - Energy in Ws"
-                    - "Query & Auto - Energy in Wh"
-                    - "Query & Auto - Energy in KWh"
-                    - "Query & Auto - Power in W"
-                    - "Query & Auto - Power in KW"
-                 command_topic: "__trash"
-                 icon: "mdi:tune"
-            - component: "number"
-              name: "meas_MAT"
-              config:
-                 command_topic: "__trash"
-                 min: "10"
-                 max: "2550"
-                 step: "10"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MIT"
-              config:
-                 command_topic: "__trash"
-                 min: "1"
-                 max: "255"
-                 step: "1"
-                 mode: "box"
-                 unit_of_measurement: "s"
-                 icon: "mdi:timer-refresh-outline"
-            - component: "number"
-              name: "meas_MD"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "4095"
-                 step: "1"
-                 mode: "box"
-                 icon: "mdi:equalizer"
-            - component: "button"
-              name: "set_meas"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('meas_type',ignorecase=True) %}
-                       {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
-                       {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
-                       {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
-                       {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
-                       {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
-                       {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
-                       {% else %}{% set ns.UN = 3 %}
-                       {% endif %}
-                     {% elif entity is search('reset_meas',ignorecase=True) %}
-                       {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
-                     {% elif entity is search('meas_mat',ignorecase=True) %}
-                       {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
-                     {% elif entity is search('meas_mit',ignorecase=True) %}
-                       {% set ns.MIT = states(entity)|int(default=1) %}
-                     {% elif entity is search('meas_md',ignorecase=True) %}
-                       {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
-                       {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
-                     {% endif %}
-                   {% endfor %}
-                   {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
-                 icon: "mdi:download"
-            - component: binary_sensor
-              name: "LC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-      0x0F:
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "switch"
-              name: "switch"
-              config:
-                 state_topic: "CMD4"
-                 state_on: "100"
-                 state_off: "0"
-                 value_template: "{{ value_json.OV }}"
-                 command_topic: "req"
-                 payload_on: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
-                 payload_off: >
-                   {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
-                 device_class: outlet
-            - component: "button"
-              name: "query_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-            - component: binary_sensor
-              name: "LC"
-              config:
-                 state_topic: "CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-      0x11: &D20111
-         device_config:
-            command: "CMD"
-            channel: "IO/CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "light"
-              name: "IO0"
-              config:
-                 schema: "template"
-                 state_topic: "IO0/CMD4"
-                 state_template: >-
-                   {% if value_json.OV == 0 %}off{% else %}on{% endif %}
-                 command_topic: "req"
-                 command_on_template: >-
-                   {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
-                 command_off_template: >-
-                   {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
-            - component: "button"
-              name: "query_status_IO0"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"0","send":"clear"}
-            - component: binary_sensor
-              name: "IO0_LC"
-              config:
-                 state_topic: "IO0/CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-            - component: "light"
-              name: "IO1"
-              config:
-                 schema: "template"
-                 state_topic: "IO1/CMD4"
-                 state_template: >-
-                   {% if value_json.OV == 0 %}off{% else %}on{% endif %}
-                 command_topic: "req"
-                 command_on_template: >-
-                   {"CMD":"1","DV":"0","IO":"1","OV":"100","send":"clear"}
-                 command_off_template: >-
-                   {"CMD":"1","DV":"0","IO":"1","OV":"0","send":"clear"}
-            - component: "button"
-              name: "query_status_IO1"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"1","send":"clear"}
-            - component: binary_sensor
-              name: "IO1_LC"
-              config:
-                 state_topic: "IO1/CMD4"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.LC == 1 %}on{% else %}off{% endif %}
-            - component: "button"
-              name: "query_status_all"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"CMD":"3","IO":"30","send":"clear"}
-      0x12: *D20111
-   0x03:
-      0x0A:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            persistent: "false"
-         entities:
-            - component: "sensor"
-              name: "battery"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.BATT }}"
-                 device_class: "battery"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "binary_sensor"
-              name: "single"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.BA == 1 %}ON{% else %}OFF{% endif %}
-                 enabled_by_default: "false"
-            - component: "binary_sensor"
-              name: "double"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.BA == 2 %}ON{% else %}OFF{% endif %}
-                 enabled_by_default: "false"
-            - component: "binary_sensor"
-              name: "long_press"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.BA == 3 %}ON{% else %}OFF{% endif %}
-                 enabled_by_default: "false"
-            - component: "binary_sensor"
-              name: "long_released"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.BA == 4 %}ON{% else %}OFF{% endif %}
-                 enabled_by_default: "false"
-            - component: "device_automation"
-              name: "trig_single"
-              config:
-                 automation_type: "trigger"
-                 type: "button_short_press"
-                 subtype: "button_1"
-                 topic: ""
-                 payload: "1"
-                 value_template: "{{ value_json.BA }}"
-            - component: "device_automation"
-              name: "trig_double"
-              config:
-                 automation_type: "trigger"
-                 type: "button_double_press"
-                 subtype: "button_1"
-                 topic: ""
-                 payload: "2"
-                 value_template: "{{ value_json.BA }}"
-            - component: "device_automation"
-              name: "trig_long_press"
-              config:
-                 automation_type: "trigger"
-                 type: "button_long_press"
-                 subtype: "button_1"
-                 topic: ""
-                 payload: "3"
-                 value_template: "{{ value_json.BA }}"
-            - component: "device_automation"
-              name: "trig_long_released"
-              config:
-                 automation_type: "trigger"
-                 type: "button_long_release"
-                 subtype: "button_1"
-                 topic: ""
-                 payload: "4"
-                 value_template: "{{ value_json.BA }}"
-   0x05:
-      0x00: &D20500
-         device_config:
-            command: "CMD"
-            channel: "CMD"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "cover"
-              name: "cover2"
-              config:
-                 command_topic: "req"
-                 payload_open: >-
-                   {"CMD":"1","POS":"0","ANG":"127","REPO":"0","LOCK":"0","CHN":"0","send":"clear"}
-                 payload_close: >-
-                   {"CMD":"1","POS":"100","ANG":"127","REPO":"0","LOCK":"0","CHN":"0","send":"clear"}
-                 payload_stop: >-
-                   {"CMD":"2","CHN":"0","send":"clear"}
-                 position_topic: "CMD4"
-                 position_open: 0
-                 position_closed: 100
-                 position_template: >-
-                   {% if (value_json.POS <= 100) and (value_json.POS >= 0) %}
-                     {{ value_json.POS }}
-                   {% else %}
-                     {{ state_attr(entity_id,"current_position")|int(default=0) }}
-                   {% endif %}
-                 set_position_topic: "req"
-                 set_position_template: >-
-                   {"CMD":"1","POS":"{{ 100 - position }}","ANG":"127","REPO":"0","LOCK":"0","CHN":"0","send":"clear"}
-                 tilt_status_topic: "CMD4"
-                 tilt_status_template: >-
-                   {% if (value_json.ANG <= 100) and (value_json.ANG >= 0) %}
-                     {{ value_json.ANG }}
-                   {% else %}
-                     {{ state_attr(entity_id,"current_tilt_position")|int(default=0) }}
-                   {% endif %}
-                 tilt_command_topic: "req"
-                 tilt_command_template: >-
-                   {"CMD":"1","POS":"127","ANG":"{{ tilt_position }}","REPO":"0","LOCK":"0","CHN":"0","send":"clear"}
-      0x02: *D20500
-   0x06:
-      0x01:
-         device_config:
-            command: "MT"
-            channel: "MT"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: binary_sensor
-              name: "burglary_alarm"
-              config:
-                 name: "Burglary alarm"
-                 state_topic: "MT0"
-                 device_class: "vibration"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.BAL >= 2 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 payload_off: "0"
-                 payload_on: "1"
-                 value_template: "{{ value_json.BAL }}"
-            - component: binary_sensor
-              name: "protection_plus_alarm"
-              config:
-                 name: "Protection plus alarm"
-                 state_topic: "MT0"
-                 device_class: "safety"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.PPAL >= 2 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 payload_off: "0"
-                 payload_on: "1"
-                 value_template: "{{ value_json.PPAL }}"
-            - component: sensor
-              name: "handle_position"
-              config:
-                 name: "Handle Position"
-                 state_topic: "MT0"
-                 device_class: "enum"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.HP >= 5 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 options:
-                    - "Undefined"
-                    - "Up"
-                    - "Down"
-                    - "Left"
-                    - "Right"
-                 value_template: >-
-                   {% set direction = {0: "Undefined", 1: "Up", 2: "Down", 3: "Left", 4: "Right"} %}
-                   {{ direction[value_json.HP] }}
-            - component: sensor
-              name: "window_state"
-              config:
-                 name: "Window State"
-                 state_topic: "MT0"
-                 device_class: "enum"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.WS >= 3 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 options:
-                    - "Undefined"
-                    - "Not Tilted"
-                    - "Tilted"
-                 value_template: >-
-                   {% set tiltness = {0: "Undefined", 1: "Not Tilted", 2: "Tilted"} %}
-                   {{ tiltness[value_json.WS] }}
-            - component: event
-              name: "button_right"
-              config:
-                 name: "Button right"
-                 state_topic: "MT0"
-                 device_class: "button"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.BR >= 3 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 event_types:
-                    - "No change"
-                    - "Button pressed"
-                    - "Button released"
-                 value_template: >-
-                   {% set button_activity = {0: "No change", 1: "Button pressed", 2: "Button released"} %}
-                   {{ button_activity[value_json.BR] }}
-            - component: event
-              name: "button_left"
-              config:
-                 name: "Button left"
-                 state_topic: "MT0"
-                 device_class: "button"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.BL >= 3 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 event_types:
-                    - "No change"
-                    - "Button pressed"
-                    - "Button released"
-                 value_template: >-
-                   {% set button_activity = {0: "No change", 1: "Button pressed", 2: "Button released"} %}
-                   {{ button_activity[value_json.BL] }}
-            - component: binary_sensor
-              name: "Motion"
-              config:
-                 state_topic: "MT0"
-                 device_class: "motion"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.M >= 2 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 payload_off: "0"
-                 payload_on: "1"
-                 value_template: "{{ value_json.M }}"
-            - component: sensor
-              name: "Temperature"
-              config:
-                 state_topic: "MT0"
-                 device_class: "temperature"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.T >= 251 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 value_template: "{{ ((value_json.T * 0.32) - 20) | round(1) }}"
-                 unit_of_measurement: "°C"
-            - component: sensor
-              name: "Humidity"
-              config:
-                 state_topic: "MT0"
-                 device_class: "humidity"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.H >= 201 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 value_template: "{{ value_json.H * 0.5 }}"
-                 unit_of_measurement: "%"
-            - component: sensor
-              name: "Illumination"
-              config:
-                 state_topic: "MT0"
-                 device_class: "illuminance"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.I >= 60001 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 value_template: "{{ value_json.I }}"
-                 unit_of_measurement: "lx"
-            - component: sensor
-              name: "Battery"
-              config:
-                 state_topic: "MT0"
-                 device_class: "battery"
-                 value_template: "{{ value_json.BS * 5 }}"
-                 unit_of_measurement: "%"
-            - component: sensor
-              name: "power_ons"
-              config:
-                 name: "Power ons"
-                 state_topic: "MT32"
-                 entity_category: "diagnostic"
-                 value_template: "{{ value_json.PON }}"
-            - component: sensor
-              name: "Alarms"
-              config:
-                 state_topic: "MT32"
-                 entity_category: "diagnostic"
-                 value_template: "{{ value_json.ALL }}"
-            - component: sensor
-              name: "handle_movements_closed"
-              config:
-                 name: "Handle movements closed"
-                 state_topic: "MT33"
-                 entity_category: "diagnostic"
-                 value_template: "{{ value_json.HMC }}"
-            - component: sensor
-              name: "handle_movements_opened"
-              config:
-                 name: "Handle movements opened"
-                 state_topic: "MT33"
-                 entity_category: "diagnostic"
-                 value_template: "{{ value_json.HMO }}"
-            - component: sensor
-              name: "handle_movements_tilted"
-              config:
-                 name: "Handle movements tilted"
-                 state_topic: "MT33"
-                 entity_category: "diagnostic"
-                 value_template: "{{ value_json.HMT }}"
-            - component: sensor
-              name: "window_tilts"
-              config:
-                 name: "Window tilts"
-                 state_topic: "MT34"
-                 entity_category: "diagnostic"
-                 value_template: "{{ value_json.WT }}"
-            - component: sensor
-              name: "button_right_presses"
-              config:
-                 name: "Button right presses"
-                 state_topic: "MT35"
-                 entity_category: "diagnostic"
-                 value_template: "{{ value_json.BRP }}"
-            - component: sensor
-              name: "button_left_presses"
-              config:
-                 name: "Button left presses"
-                 state_topic: "MT35"
-                 entity_category: "diagnostic"
-                 value_template: "{{ value_json.BLP }}"
-            - component: button
-              name: "get_configuration_settings"
-              config:
-                 name: "Get configuration settings"
-                 command_topic: "req"
-                 entity_category: "config"
-                 icon: "mdi:download"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                    {% if entity is search('vacation_mode',ignorecase=True) %}
-                     {% if is_state(entity, true) %}
-                      {% set ns.vacation_mode = 1 %}
-                     {% else %}
-                      {% set ns.vacation_mode = 0 %}
-                     {% endif %}
-                    {% endif %}
-                   {% endfor %}
-                   {"MT": "128", "GCS":"1","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
-            - component: button
-              name: "get_log_data"
-              config:
-                 name: "Get log data"
-                 command_topic: "req"
-                 entity_category: "diagnostic"
-                 icon: "mdi:download"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                    {% if entity is search('vacation_mode',ignorecase=True) %}
-                     {% if is_state(entity, true) %}
-                      {% set ns.vacation_mode = 1 %}
-                     {% else %}
-                      {% set ns.vacation_mode = 0 %}
-                     {% endif %}
-                    {% endif %}
-                   {% endfor %}
-                   {"MT":"128","GCS":"0","GLD":"1","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
-            - component: switch
-              name: "vacation_mode"
-              config:
-                 name: "Vacation mode"
-                 statc_topic: "MT16"
-                 command_topic: "req"
-                 icon: "mdi:airplane"
-                 availability_topic: "MT0"
-                 availability_template: >-
-                   {% if value_json.V >= 3 %}
-                     offline
-                   {% else %}
-                     online
-                   {% endif %}
-                 payload_on: >-
-                   {"MT": "128", "GCS":"0","GLD":"0","VMS":"1","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
-                 payload_off: >-
-                   {"MT": "128", "GCS":"0","GLD":"0","VMS":"0","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
-                 state_on: "1"
-                 state_off: "0"
-                 value_template: "{{ value_json.VMR }}"
-            - component: switch
-              name: "handle_closed_click"
-              config:
-                 name: "Handle closed click"
-                 statc_topic: "MT16"
-                 command_topic: "req"
-                 entity_category: "config"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                    {% if entity is search('vacation_mode',ignorecase=True) %}
-                     {% if is_state(entity, true) %}
-                      {% set ns.vacation_mode = 1 %}
-                     {% else %}
-                      {% set ns.vacation_mode = 0 %}
-                     {% endif %}
-                    {% endif %}
-                   {% endfor %}
-                   {"MT": "128", "GCS":"0","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"{{value}}","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
-                 payload_on: "2"
-                 payload_off: "1"
-                 state_on: "1"
-                 state_off: "0"
-                 value_template: "{{ value_json.HCCR }}"
-            - component: switch
-              name: "battery_low_click"
-              config:
-                 name: "Battery low click"
-                 statc_topic: "MT16"
-                 command_topic: "req"
-                 entity_category: "config"
-                 device_class: "switch"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                    {% if entity is search('vacation_mode',ignorecase=True) %}
-                     {% if is_state(entity, true) %}
-                      {% set ns.vacation_mode = 1 %}
-                     {% else %}
-                      {% set ns.vacation_mode = 0 %}
-                     {% endif %}
-                    {% endif %}
-                   {% endfor %}
-                   {"MT": "128", "GCS":"0","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"{{value}}","SUIS":"0","VBIS":"0","send":"clear"}
-                 payload_on: "2"
-                 payload_off: "1"
-                 state_on: "1"
-                 state_off: "0"
-                 value_template: "{{ value_json.BLCR }}"
-            - component: number
-              name: "sensor_update_interval"
-              config:
-                 name: "Sensor update interval"
-                 state_topic: "MT16"
-                 command_topic: "req"
-                 entity_category: "config"
-                 mode: "box"
-                 min: 5
-                 max: 65535
-                 unit_of_measurement: "s"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                    {% if entity is search('vacation_mode',ignorecase=True) %}
-                     {% if is_state(entity, true) %}
-                      {% set ns.vacation_mode = 1 %}
-                     {% else %}
-                      {% set ns.vacation_mode = 0 %}
-                     {% endif %}
-                    {% endif %}
-                   {% endfor %}
-                   {"MT": "128", "GCS":"0","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"0","SUIS":"{{value}}","VBIS":"0","send":"clear"}
-                 value_template: "{{ value_json.SUIR }}"
-            - component: number
-              name: "vacation_blink_interval"
-              config:
-                 name: "Vacation blink interval"
-                 state_topic: "MT16"
-                 command_topic: "req"
-                 entity_category: "config"
-                 mode: "box"
-                 min: 3
-                 max: 255
-                 unit_of_measurement: "s"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                    {% if entity is search('vacation_mode',ignorecase=True) %}
-                     {% if is_state(entity, true) %}
-                      {% set ns.vacation_mode = 1 %}
-                     {% else %}
-                      {% set ns.vacation_mode = 0 %}
-                     {% endif %}
-                    {% endif %}
-                   {% endfor %}
-                   {"MT": "128", "GCS":"0","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"{{value}}","send":"clear"}
-                 value_template: "{{ value_json.VBIR }}"
-   0x14:
-      0x30:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: binary_sensor
-              name: "alarm"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.SMA0 == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "smoke"
-            - component: binary_sensor
-              name: "fault_mode"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.SMA1 == 1 %}ON{% else %}OFF{% endif %}
-            - component: binary_sensor
-              name: "maintenance"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.SMA2 == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "problem"
-                 icon: "mdi:tools"
-            - component: binary_sensor
-              name: "humidity_range"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.SMA3 == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "problem"
-                 icon: "mdi:water-percent-alert"
-            - component: binary_sensor
-              name: "temperature_range"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.SMA4 == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "problem"
-                 icon: "mdi:thermometer-alert"
-            - component: "sensor"
-              name: "last_maintenance"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SMA5 }}"
-                 unit_of_measurement: "week"
-                 icon: "mdi:wrench-clock"
-            - component: "sensor"
-              name: "energy"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.ES == 0 %}High
-                   {% elif value_json.ES == 1 %}Medium
-                   {% elif value_json.ES == 2 %}Low
-                   {% else %}Critical
-                   {% endif %}
-                 icon: "mdi:battery-heart"
-            - component: "sensor"
-              name: "end_of_life"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.RPLT }}"
-                 unit_of_measurement: "month"
-                 icon: "mdi:calendar-clock"
-            - component: "sensor"
-              name: "temperature"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP8 | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "humidity"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM | round(1) }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "sensor"
-              name: "comfort"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.HCI == 0 %}Good
-                   {% elif value_json.HCI == 1 %}Medium
-                   {% elif value_json.HCI == 2 %}Bad
-                   {% else %}Error
-                   {% endif %}
-                 icon: "mdi:sofa"
-            - component: "sensor"
-              name: "air_quality"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.IAQTH == 0 %}Optimal
-                   {% elif value_json.IAQTH == 1 %}Dry
-                   {% elif value_json.IAQTH == 2 %}High humidity
-                   {% elif value_json.IAQTH == 3 %}High temperature and humidity
-                   {% elif value_json.IAQTH == 4 %}Out of range
-                   {% else %}Error
-                   {% endif %}
-                 icon: "mdi:weather-windy"
-      0x41:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "hum"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM | round(1) }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "sensor"
-              name: "lux"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL | round (1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "acceleration"
-              device_class: "enum"
-              options:
-                 - "Periodic update"
-                 - "Threshold 1 exceeded"
-                 - "Threshold 2 exceeded"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.ACC == 0 %} Periodic update
-                   {% elif value_json.ACC == 1 %} Threshold 1 exceeded
-                   {% elif value_json.ACC == 2 %} Threshold 2 exceeded
-                   {% endif %}
-            - component: "sensor"
-              name: "ACX"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ACX | round (3) }}"
-                 state_class: "measurement"
-                 unit_of_measurement: "g"
-            - component: "sensor"
-              name: "ACY"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ACY | round (3) }}"
-                 state_class: "measurement"
-                 unit_of_measurement: "g"
-            - component: "sensor"
-              name: "ACZ"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ACZ | round (3) }}"
-                 state_class: "measurement"
-                 unit_of_measurement: "g"
-            - component: binary_sensor
-              name: "contact"
-              config:
-                 state_topic: ""
-                 device_class: "door"
-                 value_template: >-
-                    {% if value_json.CO == 0 %} ON
-                    {% elif value_json.CO == 1 %} OFF
-                    {% endif %}
-                 icon: "mdi:door"
-   0x50:
-      0x00:
-         device_config:
-            command: "MT"
-            channel: "MT"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "button"
-              name: "query_basic_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"MT":"0","RMT":"0","send":"clear"}
-            - component: "button"
-              name: "query_extended_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"MT":"0","RMT":"1","send":"clear"}
-            - component: "select"
-              name: "operating_mode"
-              config:
-                 options:
-                    - "Off"
-                    - "Level 1"
-                    - "Level 2"
-                    - "Level 3"
-                    - "Level 4"
-                    - "Automatic"
-                    - "Automatic on demand"
-                    - "Supply air only"
-                    - "Exhaust air only"
-                 command_topic: "req"
-                 command_template: >-
-                   {% set modes = {"Off": "0", "Level 1": "1", "Level 2": "2", "Level 3": "3", "Level 4": "4", "Automatic": "11", "Automatic on demand": 12, "Supply air only": 13, "Exhaust air only": 14} %}
-                   {"MT":"1","DOMC":"{{modes[value]}}","OMC":"0","TOMC":"0","COT":"127","HT":"127","AQT":"127","send":"clear"}
-                 state_topic: "MT2"
-                 value_template: >-
-                   {% set modes = {0: "Off", 1: "Level 1", 2: "Level 2", 3: "Level 3", 4: "Level 4", 11: "Automatic", 12: "Automatic on demand", 13: "Supply air only", 14: "Exhaust air only"} %}
-                   {{ modes[value_json.OMS] }}
-                 icon: "mdi:hvac"
-            - component: "sensor"
-              name: "t_outdoor"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.OUTT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_supply"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "supply_air_flow"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYFF }}"
-                 unit_of_measurement: "m3/h"
-            - component: "sensor"
-              name: "exhaust_air_flow"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHFF }}"
-                 unit_of_measurement: "m3/h"
-            - component: "sensor"
-              name: "supply_fan_speed"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYFS }}"
-                 unit_of_measurement: "rpm"
-            - component: "sensor"
-              name: "exhaust_fan_speed"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHFS }}"
-                 unit_of_measurement: "rpm"
-            - component: "sensor"
-              name: "air_quality_sensor"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.AQS1 }}"
-                 unit_of_measurement: "%"
-            - component: binary_sensor
-              name: "filter_maintenance_required"
-              config:
-                 state_topic: "MT2"
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                    {% if value_json.FMS == 1 %}on{% else %}off{% endif %}
-      0x01:
-         device_config:
-            command: "MT"
-            channel: "MT"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "button"
-              name: "query_basic_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"MT":"0","RMT":"0","send":"clear"}
-            - component: "button"
-              name: "query_extended_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"MT":"0","RMT":"1","send":"clear"}
-            - component: "select"
-              name: "operating_mode"
-              config:
-                 options:
-                    - "Off"
-                    - "Level 1"
-                    - "Level 2"
-                    - "Level 3"
-                    - "Level 4"
-                    - "Automatic"
-                    - "Automatic on demand"
-                    - "Supply air only"
-                    - "Exhaust air only"
-                 command_topic: "req"
-                 command_template: >-
-                   {% set modes = {"Off": "0", "Level 1": "1", "Level 2": "2", "Level 3": "3", "Level 4": "4", "Automatic": "11", "Automatic on demand": 12, "Supply air only": 13, "Exhaust air only": 14} %}
-                   {"MT":"1","DOMC":"{{modes[value]}}","OMC":"0","TOMC":"0","COT":"127","HT":"127","AQT":"127","send":"clear"}
-                 state_topic: "MT2"
-                 value_template: >-
-                   {% set modes = {0: "Off", 1: "Level 1", 2: "Level 2", 3: "Level 3", 4: "Level 4", 11: "Automatic", 12: "Automatic on demand", 13: "Supply air only", 14: "Exhaust air only"} %}
-                   {{ modes[value_json.OMS] }}
-                 icon: "mdi:hvac"
-            - component: "sensor"
-              name: "t_outdoor"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.OUTT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_supply"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "supply_air_flow"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYFF }}"
-                 unit_of_measurement: "m3/h"
-            - component: "sensor"
-              name: "exhaust_air_flow"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHFF }}"
-                 unit_of_measurement: "m3/h"
-            - component: "sensor"
-              name: "supply_fan_speed"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYFS }}"
-                 unit_of_measurement: "rpm"
-            - component: "sensor"
-              name: "exhaust_fan_speed"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHFS }}"
-                 unit_of_measurement: "rpm"
-      0x10:
-         device_config:
-            command: "MT"
-            channel: "MT"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "button"
-              name: "query_basic_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"MT":"0","RMT":"0","send":"clear"}
-            - component: "button"
-              name: "query_extended_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"MT":"0","RMT":"1","send":"clear"}
-            - component: "select"
-              name: "operating_mode"
-              config:
-                 options:
-                    - "Off"
-                    - "Level 1"
-                    - "Level 2"
-                    - "Level 3"
-                    - "Level 4"
-                    - "Automatic"
-                    - "Automatic on demand"
-                    - "Supply air only"
-                    - "Exhaust air only"
-                 command_topic: "req"
-                 command_template: >-
-                   {% set modes = {"Off": "0", "Level 1": "1", "Level 2": "2", "Level 3": "3", "Level 4": "4", "Automatic": "11", "Automatic on demand": 12, "Supply air only": 13, "Exhaust air only": 14} %}
-                   {"MT":"1","DOMC":"{{modes[value]}}","OMC":"0","TOMC":"0","COT":"127","HT":"127","AQT":"127","RTT":"0","send":"clear"}
-                 state_topic: "MT2"
-                 value_template: >-
-                   {% set modes = {0: "Off", 1: "Level 1", 2: "Level 2", 3: "Level 3", 4: "Level 4", 11: "Automatic", 12: "Automatic on demand", 13: "Supply air only", 14: "Exhaust air only"} %}
-                   {{ modes[value_json.OMS] }}
-                 icon: "mdi:hvac"
-            - component: "sensor"
-              name: "t_outdoor"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.OUTT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_supply"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_indoor"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.INT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_exhaust"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "supply_air_flow"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYFF }}"
-                 unit_of_measurement: "m3/h"
-            - component: "sensor"
-              name: "exhaust_air_flow"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHFF }}"
-                 unit_of_measurement: "m3/h"
-            - component: "sensor"
-              name: "supply_fan_speed"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYFS }}"
-                 unit_of_measurement: "rpm"
-            - component: "sensor"
-              name: "exhaust_fan_speed"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHFS }}"
-                 unit_of_measurement: "rpm"
-      0x11:
-         device_config:
-            command: "MT"
-            channel: "MT"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "button"
-              name: "query_basic_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"MT":"0","RMT":"0","send":"clear"}
-            - component: "button"
-              name: "query_extended_status"
-              config:
-                 command_topic: "req"
-                 payload_press: >-
-                   {"MT":"0","RMT":"1","send":"clear"}
-            - component: "select"
-              name: "operating_mode"
-              config:
-                 options:
-                    - "Off"
-                    - "Level 1"
-                    - "Level 2"
-                    - "Level 3"
-                    - "Level 4"
-                    - "Automatic"
-                    - "Automatic on demand"
-                    - "Supply air only"
-                    - "Exhaust air only"
-                 command_topic: "req"
-                 command_template: >-
-                   {% set modes = {"Off": "0", "Level 1": "1", "Level 2": "2", "Level 3": "3", "Level 4": "4", "Automatic": "11", "Automatic on demand": 12, "Supply air only": 13, "Exhaust air only": 14} %}
-                   {"MT":"1","DOMC":"{{modes[value]}}","OMC":"0","HBC":"0","TOMC":"0","COT":"127","HT":"127","AQT":"127","RTT":"0","send":"clear"}
-                 state_topic: "MT2"
-                 value_template: >-
-                   {% set modes = {0: "Off", 1: "Level 1", 2: "Level 2", 3: "Level 3", 4: "Level 4", 11: "Automatic", 12: "Automatic on demand", 13: "Supply air only", 14: "Exhaust air only"} %}
-                   {{ modes[value_json.OMS] }}
-                 icon: "mdi:hvac"
-            - component: "sensor"
-              name: "t_outdoor"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.OUTT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_supply"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_indoor"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.INT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_exhaust"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHT }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "supply_air_flow"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYFF }}"
-                 unit_of_measurement: "m3/h"
-            - component: "sensor"
-              name: "exhaust_air_flow"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHFF }}"
-                 unit_of_measurement: "m3/h"
-            - component: "sensor"
-              name: "supply_fan_speed"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.SPLYFS }}"
-                 unit_of_measurement: "rpm"
-            - component: "sensor"
-              name: "exhaust_fan_speed"
-              config:
-                 state_topic: "MT2"
-                 value_template: "{{ value_json.EXHFS }}"
-                 unit_of_measurement: "rpm"
+  0x01:
+    0x01:
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "switch"
+        name: "switch"
+        config:
+          state_topic: "CMD4"
+          value_template: >-
+            {% if value_json.OV == 0 %}
+                OFF
+            {% elif value_json.OV >= 1 and value_json.OV <= 100 %}
+                ON
+            {% else %}
+            {% endif %}
+          command_topic: "req"
+          payload_on: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+          payload_off: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+          device_class: outlet
+      - component: "button"
+        name: "query_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+      - component: binary_sensor
+        name: "LC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+    0x08:
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "switch"
+        name: "switch"
+        config:
+          state_topic: "CMD4"
+          state_on: "100"
+          state_off: "0"
+          value_template: "{{ value_json.OV }}"
+          command_topic: "req"
+          payload_on: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+          payload_off: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+          device_class: outlet
+      - component: "sensor"
+        name: "energy"
+        config:
+          state_topic: "CMD7"
+          state_class: "total_increasing"
+          device_class: "energy"
+          unit_of_measurement: "Wh"
+          value_template: >-
+            {% if value_json.UN == 0 %}
+              {{ (value_json.MV|int / 3600)|int }}
+            {% elif value_json.UN == 1 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 2 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "sensor"
+        name: "power"
+        config:
+          state_topic: "CMD7"
+          state_class: "measurement"
+          device_class: "power"
+          unit_of_measurement: "W"
+          value_template: >-
+            {% if value_json.UN == 3 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 4 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "button"
+        name: "query_energy"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"0","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_power"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"1","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+      - component: "switch"
+        name: "reset_meas"
+        config:
+          command_topic: "__trash"
+          icon: "mdi:numeric-0-circle-outline"
+      - component: "select"
+        name: "meas_type"
+        config:
+          options:
+          - "Query only - Energy in Ws"
+          - "Query only - Energy in Wh"
+          - "Query only - Energy in KWh"
+          - "Query only - Power in W"
+          - "Query only - Power in KW"
+          - "Query & Auto - Energy in Ws"
+          - "Query & Auto - Energy in Wh"
+          - "Query & Auto - Energy in KWh"
+          - "Query & Auto - Power in W"
+          - "Query & Auto - Power in KW"
+          command_topic: "__trash"
+          icon: "mdi:tune"
+      - component: "number"
+        name: "meas_MAT"
+        config:
+          command_topic: "__trash"
+          min: "10"
+          max: "2550"
+          step: "10"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MIT"
+        config:
+          command_topic: "__trash"
+          min: "1"
+          max: "255"
+          step: "1"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MD"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "4095"
+          step: "1"
+          mode: "box"
+          icon: "mdi:equalizer"
+      - component: "button"
+        name: "set_meas"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('meas_type',ignorecase=True) %}
+                {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
+                {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
+                {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
+                {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
+                {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
+                {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
+                {% else %}{% set ns.UN = 3 %}
+                {% endif %}
+              {% elif entity is search('reset_meas',ignorecase=True) %}
+                {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
+              {% elif entity is search('meas_mat',ignorecase=True) %}
+                {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
+              {% elif entity is search('meas_mit',ignorecase=True) %}
+                {% set ns.MIT = states(entity)|int(default=1) %}
+              {% elif entity is search('meas_md',ignorecase=True) %}
+                {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
+                {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
+              {% endif %}
+            {% endfor %}
+            {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
+          icon: "mdi:download"
+      - component: binary_sensor
+        name: "OC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.OC == 1 %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "LC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+    0x09:
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "switch"
+        name: "switch"
+        config:
+          state_topic: "CMD4"
+          state_on: "100"
+          state_off: "0"
+          value_template: "{{ value_json.OV }}"
+          command_topic: "req"
+          payload_on: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+          payload_off: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+          device_class: outlet
+      - component: "sensor"
+        name: "energy"
+        config:
+          state_topic: "CMD7"
+          state_class: "total_increasing"
+          device_class: "energy"
+          unit_of_measurement: "Wh"
+          value_template: >-
+            {% if value_json.UN == 0 %}
+              {{ (value_json.MV|int / 3600)|int }}
+            {% elif value_json.UN == 1 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 2 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "sensor"
+        name: "power"
+        config:
+          state_topic: "CMD7"
+          state_class: "measurement"
+          device_class: "power"
+          unit_of_measurement: "W"
+          value_template: >-
+            {% if value_json.UN == 3 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 4 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "button"
+        name: "query_energy"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"0","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_power"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"1","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+      - component: "switch"
+        name: "reset_meas"
+        config:
+          command_topic: "__trash"
+          icon: "mdi:numeric-0-circle-outline"
+      - component: "select"
+        name: "meas_type"
+        config:
+          options:
+          - "Query only - Energy in Ws"
+          - "Query only - Energy in Wh"
+          - "Query only - Energy in KWh"
+          - "Query only - Power in W"
+          - "Query only - Power in KW"
+          - "Query & Auto - Energy in Ws"
+          - "Query & Auto - Energy in Wh"
+          - "Query & Auto - Energy in KWh"
+          - "Query & Auto - Power in W"
+          - "Query & Auto - Power in KW"
+          command_topic: "__trash"
+          icon: "mdi:tune"
+      - component: "number"
+        name: "meas_MAT"
+        config:
+          command_topic: "__trash"
+          min: "10"
+          max: "2550"
+          step: "10"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MIT"
+        config:
+          command_topic: "__trash"
+          min: "1"
+          max: "255"
+          step: "1"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MD"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "4095"
+          step: "1"
+          mode: "box"
+          icon: "mdi:equalizer"
+      - component: "button"
+        name: "set_meas"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('meas_type',ignorecase=True) %}
+                {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
+                {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
+                {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
+                {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
+                {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
+                {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
+                {% else %}{% set ns.UN = 3 %}
+                {% endif %}
+              {% elif entity is search('reset_meas',ignorecase=True) %}
+                {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
+              {% elif entity is search('meas_mat',ignorecase=True) %}
+                {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
+              {% elif entity is search('meas_mit',ignorecase=True) %}
+                {% set ns.MIT = states(entity)|int(default=1) %}
+              {% elif entity is search('meas_md',ignorecase=True) %}
+                {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
+                {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
+              {% endif %}
+            {% endfor %}
+            {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
+          icon: "mdi:download"
+      - component: binary_sensor
+        name: "OC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.OC == 1 %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "LC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+    0x0A:
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "switch"
+        name: "switch"
+        config:
+          state_topic: "CMD4"
+          state_on: "100"
+          state_off: "0"
+          value_template: "{{ value_json.OV }}"
+          command_topic: "req"
+          payload_on: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+          payload_off: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+          device_class: outlet
+      - component: "button"
+        name: "query_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+      - component: binary_sensor
+        name: "PF"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.PF == 1 %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "PFD"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.PFD == 1 %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "LC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+    0x0B:
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "switch"
+        name: "switch"
+        config:
+          state_topic: "CMD4"
+          state_on: "100"
+          state_off: "0"
+          value_template: "{{ value_json.OV }}"
+          command_topic: "req"
+          payload_on: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+          payload_off: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+          device_class: outlet
+      - component: "sensor"
+        name: "energy"
+        config:
+          state_topic: "CMD7"
+          state_class: "total_increasing"
+          device_class: "energy"
+          unit_of_measurement: "Wh"
+          value_template: >-
+            {% if value_json.UN == 0 %}
+              {{ (value_json.MV|int / 3600)|int }}
+            {% elif value_json.UN == 1 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 2 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "sensor"
+        name: "power"
+        config:
+          state_topic: "CMD7"
+          state_class: "measurement"
+          device_class: "power"
+          unit_of_measurement: "W"
+          value_template: >-
+            {% if value_json.UN == 3 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 4 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "button"
+        name: "query_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_energy"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"0","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_power"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"1","IO":"30","send":"clear"}
+      - component: "switch"
+        name: "reset_meas"
+        config:
+          command_topic: "__trash"
+          icon: "mdi:numeric-0-circle-outline"
+      - component: "select"
+        name: "meas_type"
+        config:
+          options:
+          - "Query only - Energy in Ws"
+          - "Query only - Energy in Wh"
+          - "Query only - Energy in KWh"
+          - "Query only - Power in W"
+          - "Query only - Power in KW"
+          - "Query & Auto - Energy in Ws"
+          - "Query & Auto - Energy in Wh"
+          - "Query & Auto - Energy in KWh"
+          - "Query & Auto - Power in W"
+          - "Query & Auto - Power in KW"
+          command_topic: "__trash"
+          icon: "mdi:tune"
+      - component: "number"
+        name: "meas_MAT"
+        config:
+          command_topic: "__trash"
+          min: "10"
+          max: "2550"
+          step: "10"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MIT"
+        config:
+          command_topic: "__trash"
+          min: "1"
+          max: "255"
+          step: "1"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MD"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "4095"
+          step: "1"
+          mode: "box"
+          icon: "mdi:equalizer"
+      - component: "button"
+        name: "set_meas"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('meas_type',ignorecase=True) %}
+                {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
+                {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
+                {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
+                {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
+                {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
+                {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
+                {% else %}{% set ns.UN = 3 %}
+                {% endif %}
+              {% elif entity is search('reset_meas',ignorecase=True) %}
+                {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
+              {% elif entity is search('meas_mat',ignorecase=True) %}
+                {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
+              {% elif entity is search('meas_mit',ignorecase=True) %}
+                {% set ns.MIT = states(entity)|int(default=1) %}
+              {% elif entity is search('meas_md',ignorecase=True) %}
+                {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
+                {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
+              {% endif %}
+            {% endfor %}
+            {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
+          icon: "mdi:download"
+      - component: binary_sensor
+        name: "PF"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.PF == 1 %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "PFD"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.PFD == 1 %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "LC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+    0x0C:
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "select"
+        name: "mode"
+        config:
+          options:
+          - "Off"
+          - "Comfort"
+          - "Eco"
+          - "Anti-freeze"
+          - "Comfort-1"
+          - "Comfort-2"
+          command_topic: "req"
+          command_template: >-
+            {% set modes = {"Off": "0", "Comfort": "1", "Eco": "2", "Anti-freeze": "3", "Comfort-1": "4", "Comfort-2": "5"} %}
+            {"CMD":"8","PM":"{{modes[value]}}","send":"clear"}
+          state_topic: "CMD10"
+          value_template: >-
+            {% set modes = {0: "Off", 1: "Comfort", 2: "Eco", 3: "Anti-freeze", 4: "Comfort-1", 5: "Comfort-2"} %}
+            {{modes[value_json.PM]}}
+          icon: "mdi:radiator"
+      - component: "sensor"
+        name: "energy"
+        config:
+          state_topic: "CMD7"
+          state_class: "total_increasing"
+          device_class: "energy"
+          unit_of_measurement: "Wh"
+          value_template: >-
+            {% if value_json.UN == 0 %}
+              {{ (value_json.MV|int / 3600)|int }}
+            {% elif value_json.UN == 1 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 2 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "sensor"
+        name: "power"
+        config:
+          state_topic: "CMD7"
+          state_class: "measurement"
+          device_class: "power"
+          unit_of_measurement: "W"
+          value_template: >-
+            {% if value_json.UN == 3 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 4 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "button"
+        name: "query_mode"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"9","send":"clear"}
+      - component: "button"
+        name: "query_energy"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"0","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_power"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"1","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+      - component: "switch"
+        name: "reset_meas"
+        config:
+          command_topic: "__trash"
+          icon: "mdi:numeric-0-circle-outline"
+      - component: "select"
+        name: "meas_type"
+        config:
+          options:
+          - "Query only - Energy in Ws"
+          - "Query only - Energy in Wh"
+          - "Query only - Energy in KWh"
+          - "Query only - Power in W"
+          - "Query only - Power in KW"
+          - "Query & Auto - Energy in Ws"
+          - "Query & Auto - Energy in Wh"
+          - "Query & Auto - Energy in KWh"
+          - "Query & Auto - Power in W"
+          - "Query & Auto - Power in KW"
+          command_topic: "__trash"
+          icon: "mdi:tune"
+      - component: "number"
+        name: "meas_MAT"
+        config:
+          command_topic: "__trash"
+          min: "10"
+          max: "2550"
+          step: "10"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MIT"
+        config:
+          command_topic: "__trash"
+          min: "1"
+          max: "255"
+          step: "1"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MD"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "4095"
+          step: "1"
+          mode: "box"
+          icon: "mdi:equalizer"
+      - component: "button"
+        name: "set_meas"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('meas_type',ignorecase=True) %}
+                {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
+                {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
+                {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
+                {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
+                {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
+                {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
+                {% else %}{% set ns.UN = 3 %}
+                {% endif %}
+              {% elif entity is search('reset_meas',ignorecase=True) %}
+                {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
+              {% elif entity is search('meas_mat',ignorecase=True) %}
+                {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
+              {% elif entity is search('meas_mit',ignorecase=True) %}
+                {% set ns.MIT = states(entity)|int(default=1) %}
+              {% elif entity is search('meas_md',ignorecase=True) %}
+                {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
+                {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
+              {% endif %}
+            {% endfor %}
+            {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
+          icon: "mdi:download"
+      - component: binary_sensor
+        name: "OC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.OC == 1 %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "LC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+    0x0D:
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "switch"
+        name: "switch"
+        config:
+          state_topic: "CMD4"
+          state_on: "100"
+          state_off: "0"
+          value_template: "{{ value_json.OV }}"
+          command_topic: "req"
+          payload_on: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+          payload_off: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+          device_class: outlet
+      - component: "button"
+        name: "query_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+      - component: binary_sensor
+        name: "LC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+    0x0E:
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "switch"
+        name: "switch"
+        config:
+          state_topic: "CMD4"
+          state_on: "100"
+          state_off: "0"
+          value_template: "{{ value_json.OV }}"
+          command_topic: "req"
+          payload_on: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+          payload_off: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+          device_class: outlet
+      - component: "sensor"
+        name: "energy"
+        config:
+          state_topic: "CMD7"
+          state_class: "total_increasing"
+          device_class: "energy"
+          unit_of_measurement: "Wh"
+          value_template: >-
+            {% if value_json.UN == 0 %}
+              {{ (value_json.MV|int / 3600)|int }}
+            {% elif value_json.UN == 1 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 2 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "sensor"
+        name: "power"
+        config:
+          state_topic: "CMD7"
+          state_class: "measurement"
+          device_class: "power"
+          unit_of_measurement: "W"
+          value_template: >-
+            {% if value_json.UN == 3 %}
+              {{ value_json.MV }}
+            {% elif value_json.UN == 4 %}
+              {{ value_json.MV|int * 1000 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+      - component: "button"
+        name: "query_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_energy"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"0","IO":"30","send":"clear"}
+      - component: "button"
+        name: "query_power"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"6","qu":"1","IO":"30","send":"clear"}
+      - component: "switch"
+        name: "reset_meas"
+        config:
+          command_topic: "__trash"
+          icon: "mdi:numeric-0-circle-outline"
+      - component: "select"
+        name: "meas_type"
+        config:
+          options:
+          - "Query only - Energy in Ws"
+          - "Query only - Energy in Wh"
+          - "Query only - Energy in KWh"
+          - "Query only - Power in W"
+          - "Query only - Power in KW"
+          - "Query & Auto - Energy in Ws"
+          - "Query & Auto - Energy in Wh"
+          - "Query & Auto - Energy in KWh"
+          - "Query & Auto - Power in W"
+          - "Query & Auto - Power in KW"
+          command_topic: "__trash"
+          icon: "mdi:tune"
+      - component: "number"
+        name: "meas_MAT"
+        config:
+          command_topic: "__trash"
+          min: "10"
+          max: "2550"
+          step: "10"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MIT"
+        config:
+          command_topic: "__trash"
+          min: "1"
+          max: "255"
+          step: "1"
+          mode: "box"
+          unit_of_measurement: "s"
+          icon: "mdi:timer-refresh-outline"
+      - component: "number"
+        name: "meas_MD"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "4095"
+          step: "1"
+          mode: "box"
+          icon: "mdi:equalizer"
+      - component: "button"
+        name: "set_meas"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('meas_type',ignorecase=True) %}
+                {% if states(entity) is search ('only') %}{% set ns.RM = 0 %}{% else %}{% set ns.RM = 1 %}{% endif %}
+                {% if states(entity) is search ('Energy') %}{% set ns.ep = 0 %}{% else %}{% set ns.ep = 1 %}{% endif %}
+                {% if states(entity) is search ('KWh') %}{% set ns.UN = 2 %}
+                {% elif states(entity) is search (' KW') %}{% set ns.UN = 4 %}
+                {% elif states(entity) is search (' Wh') %}{% set ns.UN = 1 %}
+                {% elif states(entity) is search (' Ws') %}{% set ns.UN = 0 %}
+                {% else %}{% set ns.UN = 3 %}
+                {% endif %}
+              {% elif entity is search('reset_meas',ignorecase=True) %}
+                {% if is_state(entity, "on") %}{% set ns.RE = 1 %}{% else %}{% set ns.RE = 0 %}{% endif %}
+              {% elif entity is search('meas_mat',ignorecase=True) %}
+                {% set ns.MAT = (states(entity)|int /10)|int(default=10) %}
+              {% elif entity is search('meas_mit',ignorecase=True) %}
+                {% set ns.MIT = states(entity)|int(default=1) %}
+              {% elif entity is search('meas_md',ignorecase=True) %}
+                {% set ns.MD_MSB = (states(entity)|int/16)|int(default=0) %}
+                {% set ns.MD_LSB = (states(entity)|int%16)|int(default=0) %}
+              {% endif %}
+            {% endfor %}
+            {"CMD":"5","RM":"{{ns.RM}}","RE":"{{ns.RE}}","ep":"{{ns.ep}}","IO":"0","MD_LSB":"{{ns.MD_LSB}}","UN":"{{ns.UN}}","MD_MSB":"{{ns.MD_MSB}}","MAT":"{{ns.MAT}}","MIT":"{{ns.MIT}}", "send":"clear"}
+          icon: "mdi:download"
+      - component: binary_sensor
+        name: "LC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+    0x0F:
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "switch"
+        name: "switch"
+        config:
+          state_topic: "CMD4"
+          state_on: "100"
+          state_off: "0"
+          value_template: "{{ value_json.OV }}"
+          command_topic: "req"
+          payload_on: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+          payload_off: >
+            {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+          device_class: outlet
+      - component: "button"
+        name: "query_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+      - component: binary_sensor
+        name: "LC"
+        config:
+          state_topic: "CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+    0x11: &D20111
+      device_config:
+        command: "CMD"
+        channel: "IO/CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "light"
+        name: "IO0"
+        config:
+          schema: "template"
+          state_topic: "IO0/CMD4"
+          state_template: >-
+            {% if value_json.OV == 0 %}off{% else %}on{% endif %}
+          command_topic: "req"
+          command_on_template: >-
+            {"CMD":"1","DV":"0","IO":"0","OV":"100","send":"clear"}
+          command_off_template: >-
+            {"CMD":"1","DV":"0","IO":"0","OV":"0","send":"clear"}
+      - component: "button"
+        name: "query_status_IO0"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"0","send":"clear"}
+      - component: binary_sensor
+        name: "IO0_LC"
+        config:
+          state_topic: "IO0/CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+      - component: "light"
+        name: "IO1"
+        config:
+          schema: "template"
+          state_topic: "IO1/CMD4"
+          state_template: >-
+            {% if value_json.OV == 0 %}off{% else %}on{% endif %}
+          command_topic: "req"
+          command_on_template: >-
+            {"CMD":"1","DV":"0","IO":"1","OV":"100","send":"clear"}
+          command_off_template: >-
+            {"CMD":"1","DV":"0","IO":"1","OV":"0","send":"clear"}
+      - component: "button"
+        name: "query_status_IO1"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"1","send":"clear"}
+      - component: binary_sensor
+        name: "IO1_LC"
+        config:
+          state_topic: "IO1/CMD4"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.LC == 1 %}on{% else %}off{% endif %}
+      - component: "button"
+        name: "query_status_all"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"CMD":"3","IO":"30","send":"clear"}
+    0x12: *D20111
+  0x03:
+    0x0A:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        persistent: "false"
+      entities:
+      - component: "sensor"
+        name: "battery"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.BATT }}"
+          device_class: "battery"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "binary_sensor"
+        name: "single"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.BA == 1 %}ON{% else %}OFF{% endif %}
+          enabled_by_default: "false"
+      - component: "binary_sensor"
+        name: "double"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.BA == 2 %}ON{% else %}OFF{% endif %}
+          enabled_by_default: "false"
+      - component: "binary_sensor"
+        name: "long_press"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.BA == 3 %}ON{% else %}OFF{% endif %}
+          enabled_by_default: "false"
+      - component: "binary_sensor"
+        name: "long_released"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.BA == 4 %}ON{% else %}OFF{% endif %}
+          enabled_by_default: "false"
+      - component: "device_automation"
+        name: "trig_single"
+        config:
+          automation_type: "trigger"
+          type: "button_short_press"
+          subtype: "button_1"
+          topic: ""
+          payload: "1"
+          value_template: "{{ value_json.BA }}"
+      - component: "device_automation"
+        name: "trig_double"
+        config:
+          automation_type: "trigger"
+          type: "button_double_press"
+          subtype: "button_1"
+          topic: ""
+          payload: "2"
+          value_template: "{{ value_json.BA }}"
+      - component: "device_automation"
+        name: "trig_long_press"
+        config:
+          automation_type: "trigger"
+          type: "button_long_press"
+          subtype: "button_1"
+          topic: ""
+          payload: "3"
+          value_template: "{{ value_json.BA }}"
+      - component: "device_automation"
+        name: "trig_long_released"
+        config:
+          automation_type: "trigger"
+          type: "button_long_release"
+          subtype: "button_1"
+          topic: ""
+          payload: "4"
+          value_template: "{{ value_json.BA }}"
+  0x05:
+    0x00: &D20500
+      device_config:
+        command: "CMD"
+        channel: "CMD"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "cover"
+        name: "cover2"
+        config:
+          command_topic: "req"
+          payload_open: >-
+            {"CMD":"1","POS":"0","ANG":"127","REPO":"0","LOCK":"0","CHN":"0","send":"clear"}
+          payload_close: >-
+            {"CMD":"1","POS":"100","ANG":"127","REPO":"0","LOCK":"0","CHN":"0","send":"clear"}
+          payload_stop: >-
+            {"CMD":"2","CHN":"0","send":"clear"}
+          position_topic: "CMD4"
+          position_open: 0
+          position_closed: 100
+          position_template: >-
+            {% if (value_json.POS <= 100) and (value_json.POS >= 0) %}
+              {{ value_json.POS }}
+            {% else %}
+              {{ state_attr(entity_id,"current_position")|int(default=0) }}
+            {% endif %}
+          set_position_topic: "req"
+          set_position_template: >-
+            {"CMD":"1","POS":"{{ 100 - position }}","ANG":"127","REPO":"0","LOCK":"0","CHN":"0","send":"clear"}
+          tilt_status_topic: "CMD4"
+          tilt_status_template: >-
+            {% if (value_json.ANG <= 100) and (value_json.ANG >= 0) %}
+              {{ value_json.ANG }}
+            {% else %}
+              {{ state_attr(entity_id,"current_tilt_position")|int(default=0) }}
+            {% endif %}
+          tilt_command_topic: "req"
+          tilt_command_template: >-
+            {"CMD":"1","POS":"127","ANG":"{{ tilt_position }}","REPO":"0","LOCK":"0","CHN":"0","send":"clear"}
+    0x02: *D20500
+  0x06:
+    0x01:
+      device_config:
+        command: "MT"
+        channel: "MT"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: binary_sensor
+        name: "burglary_alarm"
+        config:
+          name: "Burglary alarm"
+          state_topic: "MT0"
+          device_class: "vibration"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.BAL >= 2 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          payload_off: "0"
+          payload_on: "1"
+          value_template: "{{ value_json.BAL }}"
+      - component: binary_sensor
+        name: "protection_plus_alarm"
+        config:
+          name: "Protection plus alarm"
+          state_topic: "MT0"
+          device_class: "safety"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.PPAL >= 2 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          payload_off: "0"
+          payload_on: "1"
+          value_template: "{{ value_json.PPAL }}"
+      - component: sensor
+        name: "handle_position"
+        config:
+          name: "Handle Position"
+          state_topic: "MT0"
+          device_class: "enum"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.HP >= 5 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          options:
+          - "Undefined"
+          - "Up"
+          - "Down"
+          - "Left"
+          - "Right"
+          value_template: >-
+            {% set direction = {0: "Undefined", 1: "Up", 2: "Down", 3: "Left", 4: "Right"} %}
+            {{ direction[value_json.HP] }}
+      - component: sensor
+        name: "window_state"
+        config:
+          name: "Window State"
+          state_topic: "MT0"
+          device_class: "enum"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.WS >= 3 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          options:
+          - "Undefined"
+          - "Not Tilted"
+          - "Tilted"
+          value_template: >-
+            {% set tiltness = {0: "Undefined", 1: "Not Tilted", 2: "Tilted"} %}
+            {{ tiltness[value_json.WS] }}
+      - component: event
+        name: "button_right"
+        config:
+          name: "Button right"
+          state_topic: "MT0"
+          device_class: "button"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.BR >= 3 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          event_types:
+          - "No change"
+          - "Button pressed"
+          - "Button released"
+          value_template: >-
+            {% set button_activity = {0: "No change", 1: "Button pressed", 2: "Button released"} %}
+            {{ button_activity[value_json.BR] }}
+      - component: event
+        name: "button_left"
+        config:
+          name: "Button left"
+          state_topic: "MT0"
+          device_class: "button"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.BL >= 3 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          event_types:
+          - "No change"
+          - "Button pressed"
+          - "Button released"
+          value_template: >-
+            {% set button_activity = {0: "No change", 1: "Button pressed", 2: "Button released"} %}
+            {{ button_activity[value_json.BL] }}
+      - component: binary_sensor
+        name: "Motion"
+        config:
+          state_topic: "MT0"
+          device_class: "motion"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.M >= 2 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          payload_off: "0"
+          payload_on: "1"
+          value_template: "{{ value_json.M }}"
+      - component: sensor
+        name: "Temperature"
+        config:
+          state_topic: "MT0"
+          device_class: "temperature"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.T >= 251 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          value_template: "{{ ((value_json.T * 0.32) - 20) | round(1) }}"
+          unit_of_measurement: "°C"
+      - component: sensor
+        name: "Humidity"
+        config:
+          state_topic: "MT0"
+          device_class: "humidity"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.H >= 201 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          value_template: "{{ value_json.H * 0.5 }}"
+          unit_of_measurement: "%"
+      - component: sensor
+        name: "Illumination"
+        config:
+          state_topic: "MT0"
+          device_class: "illuminance"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.I >= 60001 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          value_template: "{{ value_json.I }}"
+          unit_of_measurement: "lx"
+      - component: sensor
+        name: "Battery"
+        config:
+          state_topic: "MT0"
+          device_class: "battery"
+          value_template: "{{ value_json.BS * 5 }}"
+          unit_of_measurement: "%"
+      - component: sensor
+        name: "power_ons"
+        config:
+          name: "Power ons"
+          state_topic: "MT32"
+          entity_category: "diagnostic"
+          value_template: "{{ value_json.PON }}"
+      - component: sensor
+        name: "Alarms"
+        config:
+          state_topic: "MT32"
+          entity_category: "diagnostic"
+          value_template: "{{ value_json.ALL }}"
+      - component: sensor
+        name: "handle_movements_closed"
+        config:
+          name: "Handle movements closed"
+          state_topic: "MT33"
+          entity_category: "diagnostic"
+          value_template: "{{ value_json.HMC }}"
+      - component: sensor
+        name: "handle_movements_opened"
+        config:
+          name: "Handle movements opened"
+          state_topic: "MT33"
+          entity_category: "diagnostic"
+          value_template: "{{ value_json.HMO }}"
+      - component: sensor
+        name: "handle_movements_tilted"
+        config:
+          name: "Handle movements tilted"
+          state_topic: "MT33"
+          entity_category: "diagnostic"
+          value_template: "{{ value_json.HMT }}"
+      - component: sensor
+        name: "window_tilts"
+        config:
+          name: "Window tilts"
+          state_topic: "MT34"
+          entity_category: "diagnostic"
+          value_template: "{{ value_json.WT }}"
+      - component: sensor
+        name: "button_right_presses"
+        config:
+          name: "Button right presses"
+          state_topic: "MT35"
+          entity_category: "diagnostic"
+          value_template: "{{ value_json.BRP }}"
+      - component: sensor
+        name: "button_left_presses"
+        config:
+          name: "Button left presses"
+          state_topic: "MT35"
+          entity_category: "diagnostic"
+          value_template: "{{ value_json.BLP }}"
+      - component: button
+        name: "get_configuration_settings"
+        config:
+          name: "Get configuration settings"
+          command_topic: "req"
+          entity_category: "config"
+          icon: "mdi:download"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+             {% if entity is search('vacation_mode',ignorecase=True) %}
+              {% if is_state(entity, true) %}
+               {% set ns.vacation_mode = 1 %}
+              {% else %}
+               {% set ns.vacation_mode = 0 %}
+              {% endif %}
+             {% endif %}
+            {% endfor %}
+            {"MT": "128", "GCS":"1","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
+      - component: button
+        name: "get_log_data"
+        config:
+          name: "Get log data"
+          command_topic: "req"
+          entity_category: "diagnostic"
+          icon: "mdi:download"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+             {% if entity is search('vacation_mode',ignorecase=True) %}
+              {% if is_state(entity, true) %}
+               {% set ns.vacation_mode = 1 %}
+              {% else %}
+               {% set ns.vacation_mode = 0 %}
+              {% endif %}
+             {% endif %}
+            {% endfor %}
+            {"MT":"128","GCS":"0","GLD":"1","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
+      - component: switch
+        name: "vacation_mode"
+        config:
+          name: "Vacation mode"
+          statc_topic: "MT16"
+          command_topic: "req"
+          icon: "mdi:airplane"
+          availability_topic: "MT0"
+          availability_template: >-
+            {% if value_json.V >= 3 %}
+              offline
+            {% else %}
+              online
+            {% endif %}
+          payload_on: >-
+            {"MT": "128", "GCS":"0","GLD":"0","VMS":"1","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
+          payload_off: >-
+            {"MT": "128", "GCS":"0","GLD":"0","VMS":"0","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
+          state_on: "1"
+          state_off: "0"
+          value_template: "{{ value_json.VMR }}"
+      - component: switch
+        name: "handle_closed_click"
+        config:
+          name: "Handle closed click"
+          statc_topic: "MT16"
+          command_topic: "req"
+          entity_category: "config"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+             {% if entity is search('vacation_mode',ignorecase=True) %}
+              {% if is_state(entity, true) %}
+               {% set ns.vacation_mode = 1 %}
+              {% else %}
+               {% set ns.vacation_mode = 0 %}
+              {% endif %}
+             {% endif %}
+            {% endfor %}
+            {"MT": "128", "GCS":"0","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"{{value}}","BLCS":"0","SUIS":"0","VBIS":"0","send":"clear"}
+          payload_on: "2"
+          payload_off: "1"
+          state_on: "1"
+          state_off: "0"
+          value_template: "{{ value_json.HCCR }}"
+      - component: switch
+        name: "battery_low_click"
+        config:
+          name: "Battery low click"
+          statc_topic: "MT16"
+          command_topic: "req"
+          entity_category: "config"
+          device_class: "switch"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+             {% if entity is search('vacation_mode',ignorecase=True) %}
+              {% if is_state(entity, true) %}
+               {% set ns.vacation_mode = 1 %}
+              {% else %}
+               {% set ns.vacation_mode = 0 %}
+              {% endif %}
+             {% endif %}
+            {% endfor %}
+            {"MT": "128", "GCS":"0","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"{{value}}","SUIS":"0","VBIS":"0","send":"clear"}
+          payload_on: "2"
+          payload_off: "1"
+          state_on: "1"
+          state_off: "0"
+          value_template: "{{ value_json.BLCR }}"
+      - component: number
+        name: "sensor_update_interval"
+        config:
+          name: "Sensor update interval"
+          state_topic: "MT16"
+          command_topic: "req"
+          entity_category: "config"
+          mode: "box"
+          min: 5
+          max: 65535
+          unit_of_measurement: "s"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+             {% if entity is search('vacation_mode',ignorecase=True) %}
+              {% if is_state(entity, true) %}
+               {% set ns.vacation_mode = 1 %}
+              {% else %}
+               {% set ns.vacation_mode = 0 %}
+              {% endif %}
+             {% endif %}
+            {% endfor %}
+            {"MT": "128", "GCS":"0","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"0","SUIS":"{{value}}","VBIS":"0","send":"clear"}
+          value_template: "{{ value_json.SUIR }}"
+      - component: number
+        name: "vacation_blink_interval"
+        config:
+          name: "Vacation blink interval"
+          state_topic: "MT16"
+          command_topic: "req"
+          entity_category: "config"
+          mode: "box"
+          min: 3
+          max: 255
+          unit_of_measurement: "s"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+             {% if entity is search('vacation_mode',ignorecase=True) %}
+              {% if is_state(entity, true) %}
+               {% set ns.vacation_mode = 1 %}
+              {% else %}
+               {% set ns.vacation_mode = 0 %}
+              {% endif %}
+             {% endif %}
+            {% endfor %}
+            {"MT": "128", "GCS":"0","GLD":"0","VMS":"{{ns.vacation_mode}}","HCCS":"0","BLCS":"0","SUIS":"0","VBIS":"{{value}}","send":"clear"}
+          value_template: "{{ value_json.VBIR }}"
+  0x14:
+    0x30:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: binary_sensor
+        name: "alarm"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.SMA0 == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "smoke"
+      - component: binary_sensor
+        name: "fault_mode"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.SMA1 == 1 %}ON{% else %}OFF{% endif %}
+      - component: binary_sensor
+        name: "maintenance"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.SMA2 == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "problem"
+          icon: "mdi:tools"
+      - component: binary_sensor
+        name: "humidity_range"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.SMA3 == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "problem"
+          icon: "mdi:water-percent-alert"
+      - component: binary_sensor
+        name: "temperature_range"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.SMA4 == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "problem"
+          icon: "mdi:thermometer-alert"
+      - component: "sensor"
+        name: "last_maintenance"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SMA5 }}"
+          unit_of_measurement: "week"
+          icon: "mdi:wrench-clock"
+      - component: "sensor"
+        name: "energy"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.ES == 0 %}High
+            {% elif value_json.ES == 1 %}Medium
+            {% elif value_json.ES == 2 %}Low
+            {% else %}Critical
+            {% endif %}
+          icon: "mdi:battery-heart"
+      - component: "sensor"
+        name: "end_of_life"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.RPLT }}"
+          unit_of_measurement: "month"
+          icon: "mdi:calendar-clock"
+      - component: "sensor"
+        name: "temperature"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP8 | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "humidity"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM | round(1) }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "sensor"
+        name: "comfort"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.HCI == 0 %}Good
+            {% elif value_json.HCI == 1 %}Medium
+            {% elif value_json.HCI == 2 %}Bad
+            {% else %}Error
+            {% endif %}
+          icon: "mdi:sofa"
+      - component: "sensor"
+        name: "air_quality"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.IAQTH == 0 %}Optimal
+            {% elif value_json.IAQTH == 1 %}Dry
+            {% elif value_json.IAQTH == 2 %}High humidity
+            {% elif value_json.IAQTH == 3 %}High temperature and humidity
+            {% elif value_json.IAQTH == 4 %}Out of range
+            {% else %}Error
+            {% endif %}
+          icon: "mdi:weather-windy"
+    0x41:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "hum"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM | round(1) }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "sensor"
+        name: "lux"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL | round (1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "acceleration"
+        device_class: "enum"
+        options:
+        - "Periodic update"
+        - "Threshold 1 exceeded"
+        - "Threshold 2 exceeded"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.ACC == 0 %} Periodic update
+            {% elif value_json.ACC == 1 %} Threshold 1 exceeded
+            {% elif value_json.ACC == 2 %} Threshold 2 exceeded
+            {% endif %}
+      - component: "sensor"
+        name: "ACX"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ACX | round (3) }}"
+          state_class: "measurement"
+          unit_of_measurement: "g"
+      - component: "sensor"
+        name: "ACY"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ACY | round (3) }}"
+          state_class: "measurement"
+          unit_of_measurement: "g"
+      - component: "sensor"
+        name: "ACZ"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ACZ | round (3) }}"
+          state_class: "measurement"
+          unit_of_measurement: "g"
+      - component: binary_sensor
+        name: "contact"
+        config:
+          state_topic: ""
+          device_class: "door"
+          value_template: >-
+            {% if value_json.CO == 0 %} ON
+            {% elif value_json.CO == 1 %} OFF
+            {% endif %}
+          icon: "mdi:door"
+  0x50:
+    0x00:
+      device_config:
+        command: "MT"
+        channel: "MT"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "button"
+        name: "query_basic_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"MT":"0","RMT":"0","send":"clear"}
+      - component: "button"
+        name: "query_extended_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"MT":"0","RMT":"1","send":"clear"}
+      - component: "select"
+        name: "operating_mode"
+        config:
+          options:
+          - "Off"
+          - "Level 1"
+          - "Level 2"
+          - "Level 3"
+          - "Level 4"
+          - "Automatic"
+          - "Automatic on demand"
+          - "Supply air only"
+          - "Exhaust air only"
+          command_topic: "req"
+          command_template: >-
+            {% set modes = {"Off": "0", "Level 1": "1", "Level 2": "2", "Level 3": "3", "Level 4": "4", "Automatic": "11", "Automatic on demand": 12, "Supply air only": 13, "Exhaust air only": 14} %}
+            {"MT":"1","DOMC":"{{modes[value]}}","OMC":"0","TOMC":"0","COT":"127","HT":"127","AQT":"127","send":"clear"}
+          state_topic: "MT2"
+          value_template: >-
+            {% set modes = {0: "Off", 1: "Level 1", 2: "Level 2", 3: "Level 3", 4: "Level 4", 11: "Automatic", 12: "Automatic on demand", 13: "Supply air only", 14: "Exhaust air only"} %}
+            {{ modes[value_json.OMS] }}
+          icon: "mdi:hvac"
+      - component: "sensor"
+        name: "t_outdoor"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.OUTT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_supply"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "supply_air_flow"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYFF }}"
+          unit_of_measurement: "m3/h"
+      - component: "sensor"
+        name: "exhaust_air_flow"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHFF }}"
+          unit_of_measurement: "m3/h"
+      - component: "sensor"
+        name: "supply_fan_speed"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYFS }}"
+          unit_of_measurement: "rpm"
+      - component: "sensor"
+        name: "exhaust_fan_speed"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHFS }}"
+          unit_of_measurement: "rpm"
+      - component: "sensor"
+        name: "air_quality_sensor"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.AQS1 }}"
+          unit_of_measurement: "%"
+      - component: binary_sensor
+        name: "filter_maintenance_required"
+        config:
+          state_topic: "MT2"
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.FMS == 1 %}on{% else %}off{% endif %}
+    0x01:
+      device_config:
+        command: "MT"
+        channel: "MT"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "button"
+        name: "query_basic_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"MT":"0","RMT":"0","send":"clear"}
+      - component: "button"
+        name: "query_extended_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"MT":"0","RMT":"1","send":"clear"}
+      - component: "select"
+        name: "operating_mode"
+        config:
+          options:
+          - "Off"
+          - "Level 1"
+          - "Level 2"
+          - "Level 3"
+          - "Level 4"
+          - "Automatic"
+          - "Automatic on demand"
+          - "Supply air only"
+          - "Exhaust air only"
+          command_topic: "req"
+          command_template: >-
+            {% set modes = {"Off": "0", "Level 1": "1", "Level 2": "2", "Level 3": "3", "Level 4": "4", "Automatic": "11", "Automatic on demand": 12, "Supply air only": 13, "Exhaust air only": 14} %}
+            {"MT":"1","DOMC":"{{modes[value]}}","OMC":"0","TOMC":"0","COT":"127","HT":"127","AQT":"127","send":"clear"}
+          state_topic: "MT2"
+          value_template: >-
+            {% set modes = {0: "Off", 1: "Level 1", 2: "Level 2", 3: "Level 3", 4: "Level 4", 11: "Automatic", 12: "Automatic on demand", 13: "Supply air only", 14: "Exhaust air only"} %}
+            {{ modes[value_json.OMS] }}
+          icon: "mdi:hvac"
+      - component: "sensor"
+        name: "t_outdoor"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.OUTT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_supply"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "supply_air_flow"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYFF }}"
+          unit_of_measurement: "m3/h"
+      - component: "sensor"
+        name: "exhaust_air_flow"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHFF }}"
+          unit_of_measurement: "m3/h"
+      - component: "sensor"
+        name: "supply_fan_speed"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYFS }}"
+          unit_of_measurement: "rpm"
+      - component: "sensor"
+        name: "exhaust_fan_speed"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHFS }}"
+          unit_of_measurement: "rpm"
+    0x10:
+      device_config:
+        command: "MT"
+        channel: "MT"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "button"
+        name: "query_basic_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"MT":"0","RMT":"0","send":"clear"}
+      - component: "button"
+        name: "query_extended_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"MT":"0","RMT":"1","send":"clear"}
+      - component: "select"
+        name: "operating_mode"
+        config:
+          options:
+          - "Off"
+          - "Level 1"
+          - "Level 2"
+          - "Level 3"
+          - "Level 4"
+          - "Automatic"
+          - "Automatic on demand"
+          - "Supply air only"
+          - "Exhaust air only"
+          command_topic: "req"
+          command_template: >-
+            {% set modes = {"Off": "0", "Level 1": "1", "Level 2": "2", "Level 3": "3", "Level 4": "4", "Automatic": "11", "Automatic on demand": 12, "Supply air only": 13, "Exhaust air only": 14} %}
+            {"MT":"1","DOMC":"{{modes[value]}}","OMC":"0","TOMC":"0","COT":"127","HT":"127","AQT":"127","RTT":"0","send":"clear"}
+          state_topic: "MT2"
+          value_template: >-
+            {% set modes = {0: "Off", 1: "Level 1", 2: "Level 2", 3: "Level 3", 4: "Level 4", 11: "Automatic", 12: "Automatic on demand", 13: "Supply air only", 14: "Exhaust air only"} %}
+            {{ modes[value_json.OMS] }}
+          icon: "mdi:hvac"
+      - component: "sensor"
+        name: "t_outdoor"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.OUTT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_supply"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_indoor"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.INT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_exhaust"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "supply_air_flow"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYFF }}"
+          unit_of_measurement: "m3/h"
+      - component: "sensor"
+        name: "exhaust_air_flow"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHFF }}"
+          unit_of_measurement: "m3/h"
+      - component: "sensor"
+        name: "supply_fan_speed"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYFS }}"
+          unit_of_measurement: "rpm"
+      - component: "sensor"
+        name: "exhaust_fan_speed"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHFS }}"
+          unit_of_measurement: "rpm"
+    0x11:
+      device_config:
+        command: "MT"
+        channel: "MT"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "button"
+        name: "query_basic_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"MT":"0","RMT":"0","send":"clear"}
+      - component: "button"
+        name: "query_extended_status"
+        config:
+          command_topic: "req"
+          payload_press: >-
+            {"MT":"0","RMT":"1","send":"clear"}
+      - component: "select"
+        name: "operating_mode"
+        config:
+          options:
+          - "Off"
+          - "Level 1"
+          - "Level 2"
+          - "Level 3"
+          - "Level 4"
+          - "Automatic"
+          - "Automatic on demand"
+          - "Supply air only"
+          - "Exhaust air only"
+          command_topic: "req"
+          command_template: >-
+            {% set modes = {"Off": "0", "Level 1": "1", "Level 2": "2", "Level 3": "3", "Level 4": "4", "Automatic": "11", "Automatic on demand": 12, "Supply air only": 13, "Exhaust air only": 14} %}
+            {"MT":"1","DOMC":"{{modes[value]}}","OMC":"0","HBC":"0","TOMC":"0","COT":"127","HT":"127","AQT":"127","RTT":"0","send":"clear"}
+          state_topic: "MT2"
+          value_template: >-
+            {% set modes = {0: "Off", 1: "Level 1", 2: "Level 2", 3: "Level 3", 4: "Level 4", 11: "Automatic", 12: "Automatic on demand", 13: "Supply air only", 14: "Exhaust air only"} %}
+            {{ modes[value_json.OMS] }}
+          icon: "mdi:hvac"
+      - component: "sensor"
+        name: "t_outdoor"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.OUTT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_supply"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_indoor"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.INT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_exhaust"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHT }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "supply_air_flow"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYFF }}"
+          unit_of_measurement: "m3/h"
+      - component: "sensor"
+        name: "exhaust_air_flow"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHFF }}"
+          unit_of_measurement: "m3/h"
+      - component: "sensor"
+        name: "supply_fan_speed"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.SPLYFS }}"
+          unit_of_measurement: "rpm"
+      - component: "sensor"
+        name: "exhaust_fan_speed"
+        config:
+          state_topic: "MT2"
+          value_template: "{{ value_json.EXHFS }}"
+          unit_of_measurement: "rpm"
 0xA5:
-   0x02:
-      0x01: &A50201
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-      0x02: *A50201
-      0x03: *A50201
-      0x04: *A50201
-      0x05: *A50201
-      0x06: *A50201
-      0x07: *A50201
-      0x08: *A50201
-      0x09: *A50201
-      0x0A: *A50201
-      0x0B: *A50201
-      0x10: *A50201
-      0x11: *A50201
-      0x12: *A50201
-      0x13: *A50201
-      0x14: *A50201
-      0x15: *A50201
-      0x16: *A50201
-      0x17: *A50201
-      0x18: *A50201
-      0x19: *A50201
-      0x1A: *A50201
-      0x1B: *A50201
-      0x20: *A50201
-      0x30: *A50201
-   0x04:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "h_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "hum"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM | round(1) }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "status"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TSN == 0 %}OFF{% else %}ON{% endif %}
-      0x02:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "h_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "hum"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM | round(1) }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "status"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TSN == 0 %}OFF{% else %}ON{% endif %}
-      0x03:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "h_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "hum"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM | round(1) }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-      0x04:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "h_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "hum"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM | round(1) }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-   0x06:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: "sensor"
-              name: "lux_raw"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.RS == 0 %}
-                     {{ value_json.ILL1 }}
-                   {% else %}
-                     {{ value_json.ILL2 }}
-                   {% endif %}
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "lux"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.RS == 0 %}
-                     {{ value_json.ILL1 | round(1) }}
-                   {% else %}
-                     {{ value_json.ILL2 | round(1) }}
-                   {% endif %}
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "ill1_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL1 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "ill1"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL1 | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "ill2_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL2 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "ill2"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL2 | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-      0x02:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: "sensor"
-              name: "lux_raw"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.RS == 0 %}
-                     {{ value_json.ILL1 }}
-                   {% else %}
-                     {{ value_json.ILL2 }}
-                   {% endif %}
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "lux"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.RS == 0 %}
-                     {{ value_json.ILL1 | round(2) }}
-                   {% else %}
-                     {{ value_json.ILL2 | round(2) }}
-                   {% endif %}
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "ill1_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL1 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "ill1"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL1 | round(2) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "ill2_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL2 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "ill2"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL2 | round(2) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-   0x07:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 enabled_by_default: "false"
-                 availability_topic: ""
-                 availability_template: >-
-                   {% if value_json.SVA == 1 %}
-                     online
-                   {% else %}
-                     offline
-                   {% endif %}
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 availability_topic: ""
-                 availability_template: >-
-                   {% if value_json.SVA == 1 %}
-                     online
-                   {% else %}
-                     offline
-                   {% endif %}
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: binary_sensor
-              name: "pir"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.PIRS >= 128 %}ON{% else %}OFF{% endif %}
-                 device_class: "occupancy"
-      0x02:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: binary_sensor
-              name: "pir"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.PIRS == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "occupancy"
-      0x03:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: binary_sensor
-              name: "pir"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.PIRS == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "occupancy"
-            - component: "sensor"
-              name: "lux_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "lux"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-   0x08:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: "sensor"
-              name: "lux_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "lux"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "pir"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.PIRS == 0 %}ON{% else %}OFF{% endif %}
-                 device_class: "occupancy"
-            - component: binary_sensor
-              name: "occ"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
-      0x02:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 enabled_by_default: "false"
-                 unit_of_measurement: "V"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: "sensor"
-              name: "lux_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "lux"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "pir"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.PIRS == 0 %}ON{% else %}OFF{% endif %}
-                 device_class: "occupancy"
-            - component: binary_sensor
-              name: "occ"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
-      0x03:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: "sensor"
-              name: "lux_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "lux"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.ILL | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "pir"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.PIRS == 0 %}ON{% else %}OFF{% endif %}
-                 device_class: "occupancy"
-            - component: binary_sensor
-              name: "occ"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
-   0x09:
-      0x04:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "h_raw"
-              config:
-                state_topic: ""
-                value_template: "{{ value_json.HUM }}"
-                device_class: "humidity"
-                state_class: "measurement"
-                unit_of_measurement: "%"
-                enabled_by_default: "false"
-            - component: "sensor"
-              name: "humidity"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM | round(1) }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "sensor"
-              name: "concentration"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.Conc }}"
-                 device_class: "carbon_dioxide"
-                 state_class: "measurement"
-                 unit_of_measurement: "ppm"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                state_topic: ""
-                value_template: "{{ value_json.TMP }}"
-                device_class: "temperature"
-                state_class: "measurement"
-                unit_of_measurement: "°C"
-                enabled_by_default: "false"
-            - component: "sensor"
-              name: "temperature"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "HSN"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.HSN == 0 %}OFF{% else %}ON{% endif %}
-            - component: binary_sensor
-              name: "TSN"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TSN == 0 %}OFF{% else %}ON{% endif %}
-      0x0C:
-         device_config:
-            command: ""
-            channel: "VOC_ID"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "VOCT"
-              config:
-                 state_class: "measurement"
-                 state_topic: "VOC_ID0"
-                 value_template: "{{ value_json.Conc*0.01*(10**value_json.SCM) }}"
-                 device_class: "volatile_organic_compounds_parts"
-                 unit_of_measurement: "ppb"
-   0x10:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "fanstage"
-              config:
-                 icon: "mdi:fan"
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FAN <= 41 %}Auto{% elif value_json.FAN <= 61 %}"0{% elif value_json.FAN <= 91 %}1{% elif value_json.FAN <= 111 %}2{% else %}3{% endif %}
-            - component: "sensor"
-              name: "fan_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.FAN }}"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "setpoint"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 unit_of_measurement: "°C"
-                 state_class: "measurement"
-            - component: binary_sensor
-              name: "occ"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
-      0x03:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "setpoint"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 unit_of_measurement: "°C"
-                 state_class: "measurement"
-      0x05:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "setpoint"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "occ"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
-      0x06:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "setpoint"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "nightmode"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                    {% if value_json.SLSW == 1 %}OFF{% else %}ON{% endif %}
-         virtual:
-            - component: "number"
-              name: "setpoint"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "255"
-                 step: "1"
-                 mode: "box"
-            - component: "number"
-              name: "temperature"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "40"
-                 step: "0.1"
-                 mode: "box"
-                 unit_of_measurement: "°C"
-                 icon: "mdi:thermometer"
-            - component: "switch"
-              name: "slide_switch"
-              config:
-                 command_topic: "__trash"
-            - component: "button"
-              name: "send"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('slide_switch',ignorecase=True) %}
-                       {% if is_state(entity, "on") %}{% set ns.SLSW = 1 %}{% else %}{% set ns.SLSW = 0 %}{% endif %}
-                     {% elif entity is search('setpoint',ignorecase=True) %}
-                       {% set ns.SP = (states(entity)|int)|int(default=128) %}
-                     {% elif entity is search('temperature',ignorecase=True) %}
-                       {% set ns.TMP = (40-(states(entity)|float(default=20))*255/40)|int %}
-                     {% endif %}
-                   {% endfor %}
-                   {"SP":"{{ns.SP}}","TMP":"{{ns.TMP}}","SLSW":"{{ns.SLSW}}","send":"clear"}
-                 icon: "mdi:send"
-      0x10:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "setpoint"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "h_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "hum"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM | round(1) }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "occ"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
-      0x12:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "setpoint"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "h_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "hum"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.HUM | round(1) }}"
-                 device_class: "humidity"
-                 state_class: "measurement"
-                 unit_of_measurement: "%"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-   0x12:
-      0x00:
-         device_config:
-            command: ""
-            channel: "CH/DT"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "ch00_counter"
-              config:
-                 state_topic: "CH0.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch00_current"
-              config:
-                 state_topic: "CH0.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch01_counter"
-              config:
-                 state_topic: "CH1.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch01_current"
-              config:
-                 state_topic: "CH1.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch02_counter"
-              config:
-                 state_topic: "CH2.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch02_current"
-              config:
-                 state_topic: "CH2.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch03_counter"
-              config:
-                 state_topic: "CH3.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch03_current"
-              config:
-                 state_topic: "CH3.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch04_counter"
-              config:
-                 state_topic: "CH4.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch04_current"
-              config:
-                 state_topic: "CH4.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch05_counter"
-              config:
-                 state_topic: "CH5.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch05_current"
-              config:
-                 state_topic: "CH5.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch06_counter"
-              config:
-                 state_topic: "CH6.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch06_current"
-              config:
-                 state_topic: "CH6.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch07_counter"
-              config:
-                 state_topic: "CH7.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch07_current"
-              config:
-                 state_topic: "CH7.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch08_counter"
-              config:
-                 state_topic: "CH8.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch08_current"
-              config:
-                 state_topic: "CH8.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch09_counter"
-              config:
-                 state_topic: "CH9.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch09_current"
-              config:
-                 state_topic: "CH9.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch10_counter"
-              config:
-                 state_topic: "CH10.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch10_current"
-              config:
-                 state_topic: "CH10.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch11_counter"
-              config:
-                 state_topic: "CH11.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch11_current"
-              config:
-                 state_topic: "CH11.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch12_counter"
-              config:
-                 state_topic: "CH12.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch12_current"
-              config:
-                 state_topic: "CH12.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch13_counter"
-              config:
-                 state_topic: "CH13.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch13_current"
-              config:
-                 state_topic: "CH13.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch14_counter"
-              config:
-                 state_topic: "CH14.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch14_current"
-              config:
-                 state_topic: "CH14.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch15_counter"
-              config:
-                 state_topic: "CH15.0/DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-            - component: "sensor"
-              name: "ch15_current"
-              config:
-                 state_topic: "CH15.0/DT1"
-                 state_class: "measurement"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-      0x01:
-         device_config:
-            command: ""
-            channel: "DT"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "power"
-              config:
-                 state_class: "measurement"
-                 state_topic: "DT1"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-                 device_class: "power"
-                 unit_of_measurement: "W"
-            - component: "sensor"
-              name: "energy"
-              config:
-                 state_topic: "DT0"
-                 state_class: "total"
-                 value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
-                 device_class: "energy"
-                 unit_of_measurement: "kWh"
-            - component: "sensor"
-              name: "tariff"
-              config:
-                 state_topic: "+"
-                 value_template: "{{ value_json.TI | int(default=0) }}"
-   0x13:
-      0x01:
-         device_config:
-            command: "ID"
-            channel: "ID"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "lux_raw"
-              config:
-                 state_topic: "ID1"
-                 value_template: "{{ value_json.DWS }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "lux"
-              config:
-                 state_topic: "ID1"
-                 value_template: "{{ value_json.DWS | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: "ID1"
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "temperature"
-              config:
-                 state_topic: "ID1"
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "ws_raw"
-              config:
-                 state_topic: "ID1"
-                 value_template: "{{ value_json.WND }}"
-                 icon: "mdi:weather-windy"
-                 unit_of_measurement: "m/s"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "windspeed"
-              config:
-                 state_topic: "ID1"
-                 value_template: "{{ value_json.WND | round(1) }}"
-                 icon: "mdi:weather-windy"
-                 unit_of_measurement: "m/s"
-            - component: binary_sensor
-              name: "day"
-              config:
-                 state_topic: "ID1"
-                 value_template: >-
-                   {% if value_json.DN == 0 %}OFF{% else %}ON{% endif %}
-            - component: binary_sensor
-              name: "rain"
-              config:
-                 state_topic: "ID1"
-                 value_template: >-
-                   {% if value_json.RAN == 0 %}OFF{% else %}ON{% endif %}
-            - component: "sensor"
-              name: "snw_raw"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNW * 1000 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "sun_west"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNW * 1000 | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "sns_raw"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNS * 1000 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "sun_south"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNS * 1000 | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "sne_raw"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNE * 1000 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "sun_east"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNE * 1000 | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "binary_sensor"
-              name: "hem_north"
-              config:
-                 state_topic: "ID2"
-                 value_template: >-
-                   {% if value_json.HEM == 0 %}ON{% else %}OFF{% endif %}
-            - component: "sensor"
-              name: "hemisphere"
-              config:
-                 state_topic: "ID2"
-                 value_template: >-
-                   {% if value_json.HEM == 0 %}North{% else %}South{% endif %}
-            - component: "sensor"
-              name: "date"
-              config:
-                 state_topic: "ID3"
-                 value_template: >-
-                   {% set d=strptime((value_json.DY|int(default=0) ~ '-' ~ value_json.MTH|int(default=0) ~ '-' ~ value_json.YR|int(default=0)),'%d-%m-%Y') %}
-                   {{ d.date() }}
-                 icon: "mdi:calendar-range"
-            - component: "sensor"
-              name: "date_source"
-              config:
-                 state_topic: "ID3"
-                 value_template: >-
-                   {% if value_json.SRC == 0 %}Real Time Clock{% else %}Radio Waves{% endif %}
-            - component: "sensor"
-              name: "weekday"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {% set map = {"1":"Monday","2":"Tuesday","3":"Wednesday","4":"Thursday","5":"Friday","6":"Saturday","7":"Sunday"} %}
-                   {{ map[value_json.WDY|string] }}
-                 icon: "mdi:calendar"
-            - component: "sensor"
-              name: "time"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {{ strptime((value_json.HR|int(default=0)~':'~value_json.MIN|int(default=0)~':'~value_json.SEC|int(default=0)),'%H:%M:%S').time() }}
-                 icon: "mdi:clock-outline"
-            - component: "sensor"
-              name: "am_pm"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {% if value_json.AMPM == 0 %}AM{% else %}PM{% endif %}
-                 icon: "mdi:radio-am"
-            - component: "sensor"
-              name: "time_format"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {% if value_json.TMF == 0 %}24{% else %}12{% endif %}
-            - component: "sensor"
-              name: "time_source"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {% if value_json.SRC == 0 %}Real Time Clock{% else %}Radio Waves{% endif %}
-            - component: "sensor"
-              name: "elevation"
-              config:
-                 state_topic: "ID5"
-                 value_template: "{{ value_json.ELV }}"
-                 unit_of_measurement: "°"
-                 icon: "mdi:elevation-rise"
-            - component: "sensor"
-              name: "azimuth"
-              config:
-                 state_topic: "ID5"
-                 value_template: "{{ value_json.AZM }}"
-                 unit_of_measurement: "°"
-                 icon: "mdi:sun-compass"
-            - component: "sensor"
-              name: "latitude"
-              config:
-                 state_topic: "ID6"
-                 value_template: "{{ (value_json.LAT_MSB*256+value_json.LAT_LSB)*180/4095-90 }}"
-                 unit_of_measurement: "°"
-                 icon: "mdi:latitude"
-            - component: "sensor"
-              name: "longitude"
-              config:
-                 state_topic: "ID6"
-                 value_template: "{{ (value_json.LOT_MSB*256+value_json.LOT_LSB)*360/4095-180 }}"
-                 unit_of_measurement: "°"
-                 icon: "mdi:longitude"
-      0x02:
-         device_config:
-            command: "ID"
-            channel: "ID"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "snw_raw"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNW * 1000 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "sun_west"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNW * 1000 | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "sns_raw"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNS * 1000 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "sun_south"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNS * 1000 | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "sensor"
-              name: "sne_raw"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNE * 1000 }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "sun_east"
-              config:
-                 state_topic: "ID2"
-                 value_template: "{{ value_json.SNE * 1000 | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: "binary_sensor"
-              name: "hem_north"
-              config:
-                 state_topic: "ID2"
-                 value_template: >-
-                   {% if value_json.HEM == 0 %}ON{% else %}OFF{% endif %}
-            - component: "sensor"
-              name: "hemisphere"
-              config:
-                 state_topic: "ID2"
-                 value_template: >-
-                   {% if value_json.HEM == 0 %}North{% else %}South{% endif %}
-      0x03:
-         device_config:
-            command: "ID"
-            channel: "ID"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "date"
-              config:
-                 state_topic: "ID3"
-                 value_template: >-
-                   {% set d=strptime((value_json.DY|int(default=0) ~ '-' ~ value_json.MTH|int(default=0) ~ '-' ~ value_json.YR|int(default=0)),'%d-%m-%Y') %}
-                   {{ d.date() }}
-                 icon: "mdi:calendar-range"
-            - component: "sensor"
-              name: "date_source"
-              config:
-                 state_topic: "ID3"
-                 value_template: >-
-                   {% if value_json.SRC == 0 %}Real Time Clock{% else %}Radio Waves{% endif %}
-      0x04:
-         device_config:
-            command: "ID"
-            channel: "ID"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "weekday"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {% set map = {"1":"Monday","2":"Tuesday","3":"Wednesday","4":"Thursday","5":"Friday","6":"Saturday","7":"Sunday"} %}
-                   {{ map[value_json.WDY|string] }}
-                 icon: "mdi:calendar"
-            - component: "sensor"
-              name: "time"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {{ strptime((value_json.HR|int(default=0)~':'~value_json.MIN|int(default=0)~':'~value_json.SEC|int(default=0)),'%H:%M:%S').time() }}
-                 icon: "mdi:clock-outline"
-            - component: "sensor"
-              name: "am_pm"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {% if value_json.AMPM == 0 %}AM{% else %}PM{% endif %}
-                 icon: "mdi:radio-am"
-            - component: "sensor"
-              name: "time_format"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {% if value_json.TMF == 0 %}24{% else %}12{% endif %}
-            - component: "sensor"
-              name: "time_source"
-              config:
-                 state_topic: "ID4"
-                 value_template: >-
-                   {% if value_json.SRC == 0 %}Real Time Clock{% else %}Radio Waves{% endif %}
-      0x05:
-         device_config:
-            command: "ID"
-            channel: "ID"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "elevation"
-              config:
-                 state_topic: "ID5"
-                 value_template: "{{ value_json.ELV }}"
-                 unit_of_measurement: "°"
-                 icon: "mdi:elevation-rise"
-            - component: "sensor"
-              name: "azimuth"
-              config:
-                 state_topic: "ID5"
-                 value_template: "{{ value_json.AZM }}"
-                 unit_of_measurement: "°"
-                 icon: "mdi:sun-compass"
-      0x06:
-         device_config:
-            command: "ID"
-            channel: "ID"
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "latitude"
-              config:
-                 state_topic: "ID6"
-                 value_template: "{{ (value_json.LAT_MSB*256+value_json.LAT_LSB)*180/4095-90 }}"
-                 unit_of_measurement: "°"
-                 icon: "mdi:latitude"
-            - component: "sensor"
-              name: "longitude"
-              config:
-                 state_topic: "ID6"
-                 value_template: "{{ (value_json.LOT_MSB*256+value_json.LOT_LSB)*360/4095-180 }}"
-                 unit_of_measurement: "°"
-                 icon: "mdi:longitude"
-   0x14:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 unit_of_measurement: "V"
-                 state_class: "measurement"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: binary_sensor
-              name: "contact"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.CT == 0 %}OFF{% else %}ON{% endif %}
-                 device_class: "window"
-      0x09:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 unit_of_measurement: "V"
-                 state_class: "measurement"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: binary_sensor
-              name: "state_2p"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.CT == 0 %}OFF{% else %}ON{% endif %}
-                 device_class: "window"
-            - component: sensor
-              name: "state_3p"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.CT == 0 %}closed{% elif value_json.CT == 1 %}tilt{% elif value_json.CT == 3 %}open{% else %}reserved{% endif %}
-      0x0A:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "v_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC }}"
-                 device_class: "voltage"
-                 unit_of_measurement: "V"
-                 state_class: "measurement"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: binary_sensor
-              name: "state_2p"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.CT == 0 %}OFF{% else %}ON{% endif %}
-                 device_class: "window"
-            - component: sensor
-              name: "state_3p"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.CT == 0 %}closed{% elif value_json.CT == 1 %}tilt{% elif value_json.CT == 3 %}open{% else %}reserved{% endif %}
-            - component: binary_sensor
-              name: "vib"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.VIB == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "vibration"
-   0x20:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: "1"
-            answer: "1"
-         entities:
-            - component: "sensor"
-              name: "curval"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.CV }}"
-                 unit_of_measurement: "%"
-                 icon: "mdi:valve"
-            - component: "binary_sensor"
-              name: "SO"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                    {% if value_json.SO == 1 %}ON{% else %}OFF{% endif %}
-            - component: "binary_sensor"
-              name: "ENIE"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                    {% if value_json.ENIE == 1 %}ON{% else %}OFF{% endif %}
-            - component: "binary_sensor"
-              name: "ES"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                    {% if value_json.ES == 1 %}ON{% else %}OFF{% endif %}
-            - component: "binary_sensor"
-              name: "BCAP"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                    {% if value_json.BCAP == 1 %}OFF{% else %}ON{% endif %}
-                 device_class: "battery"
-            - component: "binary_sensor"
-              name: "CCO"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                    {% if value_json.CCO == 1 %}ON{% else %}OFF{% endif %}
-            - component: "binary_sensor"
-              name: "FTS"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                    {% if value_json.FTS == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "problem"
-            - component: "binary_sensor"
-              name: "DWO"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                    {% if value_json.DWO == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "window"
-            - component: "binary_sensor"
-              name: "ACO"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                    {% if value_json.ACO == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "problem"
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "number"
-              name: "config_valve_position"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "100"
-                 step: "1"
-                 mode: "slider"
-                 unit_of_measurement: "%"
-                 icon: "mdi:valve"
-            - component: "number"
-              name: "config_t_setpoint"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "40"
-                 step: "0.25"
-                 mode: "slider"
-                 unit_of_measurement: "°C"
-                 icon: "mdi:thermometer"
-            - component: "number"
-              name: "config_t_RCU"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "40"
-                 step: "0.25"
-                 mode: "slider"
-                 unit_of_measurement: "°C"
-                 icon: "mdi:thermometer"
-            - component: "switch"
-              name: "config_RIN"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_LFS"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_VO"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_VC"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_SB"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_SPS"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_SPN"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_RCU"
-              config:
-                 command_topic: "__trash"
-            - component: "button"
-              name: "set_config"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('config_valve_position',ignorecase=True) %}
-                       {% set ns.valve_position = (states(entity)|int(default=0)) %}
-                     {% elif entity is search('config_t_setpoint',ignorecase=True) %}
-                       {% set ns.temperature_setpoint = ((states(entity)|int(default=0))*255/40)|int %}
-                     {% elif entity is search('config_t_RCU',ignorecase=True) %}
-                       {% set ns.TMP = (states(entity)|float(default=0.0)) %}
-                     {% elif entity is search('config_RIN',ignorecase=True) %}
-                       {% set ns.RIN = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_LFS',ignorecase=True) %}
-                       {% set ns.LFS = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_SPS',ignorecase=True) %}
-                       {% set ns.SPS = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_SPN',ignorecase=True) %}
-                       {% set ns.SPN = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_RCU',ignorecase=True) %}
-                       {% set ns.RCU = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_VO',ignorecase=True) %}
-                       {% set ns.VO = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_VC',ignorecase=True) %}
-                       {% set ns.VC = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_SB',ignorecase=True) %}
-                       {% set ns.SB = iif(is_state(entity, "on"), 1, 0) %}
-                     {% endif %}
-                   {% endfor %}
-                   {% set ns.SP = iif((ns.SPS == 1), ns.temperature_setpoint, ns.valve_position) %}
-                   {"SP":{{ns.SP}},"TMP":{{ns.TMP}},"RIN":{{ns.RIN}},"LFS":{{ns.LFS}},"VO":{{ns.VO}},"VC":{{ns.VC}},"SB":{{ns.SB}},"SPS":{{ns.SPS}},"SPN":{{ns.SPN}},"RCU":{{ns.RCU}}}
-                 icon: "mdi:download"
-      0x04:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: "1"
-            answer: "1"
-         entities:
-            - component: "sensor"
-              name: "curval"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.CP }}"
-                 unit_of_measurement: "%"
-                 icon: "mdi:valve"
-            - component: "sensor"
-              name: "ft_raw"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TS == 0 %}
-                     {{ value_json.FTS * 60 / 255 + 20 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "feed_temperature"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TS == 0 %}
-                     {{ (value_json.FTS * 60 / 255 + 20) | round(1) }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "st_raw"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TS == 1 %}
-                     {{ value_json.FTS * 20 / 255 + 10 }}
-                   {% endif %}
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "setpoint_temperature"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TS == 1 %}
-                     {{ (value_json.FTS * 20 / 255 + 10) | round(1) }}
-                   {% endif %}
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "rt_raw"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FL == 0 %}
-                     {{ value_json.TMPFC * 20 / 255 + 10 }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-                 device_class: "temperature"
-                 unit_of_measurement: "°C"
-                 state_class: "measurement"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "room_temperature"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FL == 0 %}
-                     {{ (value_json.TMPFC * 20 / 255 + 10) | round(1) }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "binary_sensor"
-              name: "err_meas"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FL == 1 %}
-                     {% if value_json.TMPFC == 17 %}ON{% else %}OFF{% endif %}
-                   {% else %}
-                     {{ states(entity_id) }}
-                   {% endif %}
-                 device_class: "problem"
-            - component: "binary_sensor"
-              name: "battery"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FL == 1 %}
-                     {% if value_json.TMPFC == 18 %}ON{% else %}OFF{% endif %}
-                   {% else %}
-                     {{ states(entity_id) }}
-                   {% endif %}
-                 device_class: "battery"
-            - component: "binary_sensor"
-              name: "err_frost_prot"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FL == 1 %}
-                     {% if value_json.TMPFC == 20 %}ON{% else %}OFF{% endif %}
-                   {% else %}
-                     {{ states(entity_id) }}
-                   {% endif %}
-                 device_class: "problem"
-            - component: "binary_sensor"
-              name: "err_blocked_valve"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FL == 1 %}
-                     {% if value_json.TMPFC == 33 %}ON{% else %}OFF{% endif %}
-                   {% else %}
-                     {{ states(entity_id) }}
-                   {% endif %}
-                 device_class: "problem"
-            - component: "binary_sensor"
-              name: "err_endpoint"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FL == 1 %}
-                     {% if value_json.TMPFC == 36 %}ON{% else %}OFF{% endif %}
-                   {% else %}
-                     {{ states(entity_id) }}
-                   {% endif %}
-                 device_class: "problem"
-            - component: "binary_sensor"
-              name: "err_novalve"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FL == 1 %}
-                     {% if value_json.TMPFC == 40 %}ON{% else %}OFF{% endif %}
-                   {% else %}
-                     {{ states(entity_id) }}
-                   {% endif %}
-                 device_class: "problem"
+  0x02:
+    0x01: &A50201
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+    0x02: *A50201
+    0x03: *A50201
+    0x04: *A50201
+    0x05: *A50201
+    0x06: *A50201
+    0x07: *A50201
+    0x08: *A50201
+    0x09: *A50201
+    0x0A: *A50201
+    0x0B: *A50201
+    0x10: *A50201
+    0x11: *A50201
+    0x12: *A50201
+    0x13: *A50201
+    0x14: *A50201
+    0x15: *A50201
+    0x16: *A50201
+    0x17: *A50201
+    0x18: *A50201
+    0x19: *A50201
+    0x1A: *A50201
+    0x1B: *A50201
+    0x20: *A50201
+    0x30: *A50201
+  0x04:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "h_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "hum"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM | round(1) }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "status"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TSN == 0 %}OFF{% else %}ON{% endif %}
+    0x02:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "h_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "hum"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM | round(1) }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "status"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TSN == 0 %}OFF{% else %}ON{% endif %}
+    0x03:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "h_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "hum"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM | round(1) }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+    0x04:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "h_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "hum"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM | round(1) }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+  0x06:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: "sensor"
+        name: "lux_raw"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.RS == 0 %}
+              {{ value_json.ILL1 }}
+            {% else %}
+              {{ value_json.ILL2 }}
+            {% endif %}
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "lux"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.RS == 0 %}
+              {{ value_json.ILL1 | round(1) }}
+            {% else %}
+              {{ value_json.ILL2 | round(1) }}
+            {% endif %}
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "ill1_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL1 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "ill1"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL1 | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "ill2_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL2 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "ill2"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL2 | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+    0x02:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: "sensor"
+        name: "lux_raw"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.RS == 0 %}
+              {{ value_json.ILL1 }}
+            {% else %}
+              {{ value_json.ILL2 }}
+            {% endif %}
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "lux"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.RS == 0 %}
+              {{ value_json.ILL1 | round(2) }}
+            {% else %}
+              {{ value_json.ILL2 | round(2) }}
+            {% endif %}
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "ill1_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL1 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "ill1"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL1 | round(2) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "ill2_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL2 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "ill2"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL2 | round(2) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+  0x07:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          enabled_by_default: "false"
+          availability_topic: ""
+          availability_template: >-
+            {% if value_json.SVA == 1 %}
+              online
+            {% else %}
+              offline
+            {% endif %}
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          availability_topic: ""
+          availability_template: >-
+            {% if value_json.SVA == 1 %}
+              online
+            {% else %}
+              offline
+            {% endif %}
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: binary_sensor
+        name: "pir"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.PIRS >= 128 %}ON{% else %}OFF{% endif %}
+          device_class: "occupancy"
+    0x02:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: binary_sensor
+        name: "pir"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.PIRS == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "occupancy"
+    0x03:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: binary_sensor
+        name: "pir"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.PIRS == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "occupancy"
+      - component: "sensor"
+        name: "lux_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "lux"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+  0x08:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: "sensor"
+        name: "lux_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "lux"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "pir"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.PIRS == 0 %}ON{% else %}OFF{% endif %}
+          device_class: "occupancy"
+      - component: binary_sensor
+        name: "occ"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
+    0x02:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          enabled_by_default: "false"
+          unit_of_measurement: "V"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: "sensor"
+        name: "lux_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "lux"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "pir"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.PIRS == 0 %}ON{% else %}OFF{% endif %}
+          device_class: "occupancy"
+      - component: binary_sensor
+        name: "occ"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
+    0x03:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: "sensor"
+        name: "lux_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "lux"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.ILL | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "pir"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.PIRS == 0 %}ON{% else %}OFF{% endif %}
+          device_class: "occupancy"
+      - component: binary_sensor
+        name: "occ"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
+  0x09:
+    0x04:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "h_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "humidity"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM | round(1) }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "sensor"
+        name: "concentration"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.Conc }}"
+          device_class: "carbon_dioxide"
+          state_class: "measurement"
+          unit_of_measurement: "ppm"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "temperature"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "HSN"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.HSN == 0 %}OFF{% else %}ON{% endif %}
+      - component: binary_sensor
+        name: "TSN"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TSN == 0 %}OFF{% else %}ON{% endif %}
+    0x0C:
+      device_config:
+        command: ""
+        channel: "VOC_ID"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "VOCT"
+        config:
+          state_class: "measurement"
+          state_topic: "VOC_ID0"
+          value_template: "{{ value_json.Conc*0.01*(10**value_json.SCM) }}"
+          device_class: "volatile_organic_compounds_parts"
+          unit_of_measurement: "ppb"
+  0x10:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "fanstage"
+        config:
+          icon: "mdi:fan"
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FAN <= 41 %}Auto{% elif value_json.FAN <= 61 %}"0{% elif value_json.FAN <= 91 %}1{% elif value_json.FAN <= 111 %}2{% else %}3{% endif %}
+      - component: "sensor"
+        name: "fan_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.FAN }}"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "setpoint"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          unit_of_measurement: "°C"
+          state_class: "measurement"
+      - component: binary_sensor
+        name: "occ"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
+    0x03:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "setpoint"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          unit_of_measurement: "°C"
+          state_class: "measurement"
+    0x05:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "setpoint"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "occ"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
+    0x06:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "setpoint"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "nightmode"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.SLSW == 1 %}OFF{% else %}ON{% endif %}
+      virtual:
+      - component: "number"
+        name: "setpoint"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "255"
+          step: "1"
+          mode: "box"
+      - component: "number"
+        name: "temperature"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "40"
+          step: "0.1"
+          mode: "box"
+          unit_of_measurement: "°C"
+          icon: "mdi:thermometer"
+      - component: "switch"
+        name: "slide_switch"
+        config:
+          command_topic: "__trash"
+      - component: "button"
+        name: "send"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('slide_switch',ignorecase=True) %}
+                {% if is_state(entity, "on") %}{% set ns.SLSW = 1 %}{% else %}{% set ns.SLSW = 0 %}{% endif %}
+              {% elif entity is search('setpoint',ignorecase=True) %}
+                {% set ns.SP = (states(entity)|int)|int(default=128) %}
+              {% elif entity is search('temperature',ignorecase=True) %}
+                {% set ns.TMP = (40-(states(entity)|float(default=20))*255/40)|int %}
+              {% endif %}
+            {% endfor %}
+            {"SP":"{{ns.SP}}","TMP":"{{ns.TMP}}","SLSW":"{{ns.SLSW}}","send":"clear"}
+          icon: "mdi:send"
+    0x10:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "setpoint"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "h_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "hum"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM | round(1) }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "occ"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.OCC == 0 %}ON{% else %}OFF{% endif %}
+    0x12:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "setpoint"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "h_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "hum"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.HUM | round(1) }}"
+          device_class: "humidity"
+          state_class: "measurement"
+          unit_of_measurement: "%"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+  0x12:
+    0x00:
+      device_config:
+        command: ""
+        channel: "CH/DT"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "ch00_counter"
+        config:
+          state_topic: "CH0.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch00_current"
+        config:
+          state_topic: "CH0.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch01_counter"
+        config:
+          state_topic: "CH1.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch01_current"
+        config:
+          state_topic: "CH1.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch02_counter"
+        config:
+          state_topic: "CH2.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch02_current"
+        config:
+          state_topic: "CH2.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch03_counter"
+        config:
+          state_topic: "CH3.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch03_current"
+        config:
+          state_topic: "CH3.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch04_counter"
+        config:
+          state_topic: "CH4.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch04_current"
+        config:
+          state_topic: "CH4.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch05_counter"
+        config:
+          state_topic: "CH5.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch05_current"
+        config:
+          state_topic: "CH5.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch06_counter"
+        config:
+          state_topic: "CH6.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch06_current"
+        config:
+          state_topic: "CH6.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch07_counter"
+        config:
+          state_topic: "CH7.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch07_current"
+        config:
+          state_topic: "CH7.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch08_counter"
+        config:
+          state_topic: "CH8.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch08_current"
+        config:
+          state_topic: "CH8.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch09_counter"
+        config:
+          state_topic: "CH9.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch09_current"
+        config:
+          state_topic: "CH9.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch10_counter"
+        config:
+          state_topic: "CH10.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch10_current"
+        config:
+          state_topic: "CH10.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch11_counter"
+        config:
+          state_topic: "CH11.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch11_current"
+        config:
+          state_topic: "CH11.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch12_counter"
+        config:
+          state_topic: "CH12.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch12_current"
+        config:
+          state_topic: "CH12.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch13_counter"
+        config:
+          state_topic: "CH13.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch13_current"
+        config:
+          state_topic: "CH13.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch14_counter"
+        config:
+          state_topic: "CH14.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch14_current"
+        config:
+          state_topic: "CH14.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch15_counter"
+        config:
+          state_topic: "CH15.0/DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+      - component: "sensor"
+        name: "ch15_current"
+        config:
+          state_topic: "CH15.0/DT1"
+          state_class: "measurement"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+    0x01:
+      device_config:
+        command: ""
+        channel: "DT"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "power"
+        config:
+          state_class: "measurement"
+          state_topic: "DT1"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+          device_class: "power"
+          unit_of_measurement: "W"
+      - component: "sensor"
+        name: "energy"
+        config:
+          state_topic: "DT0"
+          state_class: "total"
+          value_template: "{{ value_json.MR/(10**value_json.DIV) }}"
+          device_class: "energy"
+          unit_of_measurement: "kWh"
+      - component: "sensor"
+        name: "tariff"
+        config:
+          state_topic: "+"
+          value_template: "{{ value_json.TI | int(default=0) }}"
+  0x13:
+    0x01:
+      device_config:
+        command: "ID"
+        channel: "ID"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "lux_raw"
+        config:
+          state_topic: "ID1"
+          value_template: "{{ value_json.DWS }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "lux"
+        config:
+          state_topic: "ID1"
+          value_template: "{{ value_json.DWS | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: "ID1"
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "temperature"
+        config:
+          state_topic: "ID1"
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "ws_raw"
+        config:
+          state_topic: "ID1"
+          value_template: "{{ value_json.WND }}"
+          icon: "mdi:weather-windy"
+          unit_of_measurement: "m/s"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "windspeed"
+        config:
+          state_topic: "ID1"
+          value_template: "{{ value_json.WND | round(1) }}"
+          icon: "mdi:weather-windy"
+          unit_of_measurement: "m/s"
+      - component: binary_sensor
+        name: "day"
+        config:
+          state_topic: "ID1"
+          value_template: >-
+            {% if value_json.DN == 0 %}OFF{% else %}ON{% endif %}
+      - component: binary_sensor
+        name: "rain"
+        config:
+          state_topic: "ID1"
+          value_template: >-
+            {% if value_json.RAN == 0 %}OFF{% else %}ON{% endif %}
+      - component: "sensor"
+        name: "snw_raw"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNW * 1000 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "sun_west"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNW * 1000 | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "sns_raw"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNS * 1000 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "sun_south"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNS * 1000 | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "sne_raw"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNE * 1000 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "sun_east"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNE * 1000 | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "binary_sensor"
+        name: "hem_north"
+        config:
+          state_topic: "ID2"
+          value_template: >-
+            {% if value_json.HEM == 0 %}ON{% else %}OFF{% endif %}
+      - component: "sensor"
+        name: "hemisphere"
+        config:
+          state_topic: "ID2"
+          value_template: >-
+            {% if value_json.HEM == 0 %}North{% else %}South{% endif %}
+      - component: "sensor"
+        name: "date"
+        config:
+          state_topic: "ID3"
+          value_template: >-
+            {% set d=strptime((value_json.DY|int(default=0) ~ '-' ~ value_json.MTH|int(default=0) ~ '-' ~ value_json.YR|int(default=0)),'%d-%m-%Y') %}
+            {{ d.date() }}
+          icon: "mdi:calendar-range"
+      - component: "sensor"
+        name: "date_source"
+        config:
+          state_topic: "ID3"
+          value_template: >-
+            {% if value_json.SRC == 0 %}Real Time Clock{% else %}Radio Waves{% endif %}
+      - component: "sensor"
+        name: "weekday"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {% set map = {"1":"Monday","2":"Tuesday","3":"Wednesday","4":"Thursday","5":"Friday","6":"Saturday","7":"Sunday"} %}
+            {{ map[value_json.WDY|string] }}
+          icon: "mdi:calendar"
+      - component: "sensor"
+        name: "time"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {{ strptime((value_json.HR|int(default=0)~':'~value_json.MIN|int(default=0)~':'~value_json.SEC|int(default=0)),'%H:%M:%S').time() }}
+          icon: "mdi:clock-outline"
+      - component: "sensor"
+        name: "am_pm"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {% if value_json.AMPM == 0 %}AM{% else %}PM{% endif %}
+          icon: "mdi:radio-am"
+      - component: "sensor"
+        name: "time_format"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {% if value_json.TMF == 0 %}24{% else %}12{% endif %}
+      - component: "sensor"
+        name: "time_source"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {% if value_json.SRC == 0 %}Real Time Clock{% else %}Radio Waves{% endif %}
+      - component: "sensor"
+        name: "elevation"
+        config:
+          state_topic: "ID5"
+          value_template: "{{ value_json.ELV }}"
+          unit_of_measurement: "°"
+          icon: "mdi:elevation-rise"
+      - component: "sensor"
+        name: "azimuth"
+        config:
+          state_topic: "ID5"
+          value_template: "{{ value_json.AZM }}"
+          unit_of_measurement: "°"
+          icon: "mdi:sun-compass"
+      - component: "sensor"
+        name: "latitude"
+        config:
+          state_topic: "ID6"
+          value_template: "{{ (value_json.LAT_MSB*256+value_json.LAT_LSB)*180/4095-90 }}"
+          unit_of_measurement: "°"
+          icon: "mdi:latitude"
+      - component: "sensor"
+        name: "longitude"
+        config:
+          state_topic: "ID6"
+          value_template: "{{ (value_json.LOT_MSB*256+value_json.LOT_LSB)*360/4095-180 }}"
+          unit_of_measurement: "°"
+          icon: "mdi:longitude"
+    0x02:
+      device_config:
+        command: "ID"
+        channel: "ID"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "snw_raw"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNW * 1000 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "sun_west"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNW * 1000 | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "sns_raw"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNS * 1000 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "sun_south"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNS * 1000 | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "sensor"
+        name: "sne_raw"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNE * 1000 }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "sun_east"
+        config:
+          state_topic: "ID2"
+          value_template: "{{ value_json.SNE * 1000 | round(1) }}"
+          device_class: "illuminance"
+          state_class: "measurement"
+          unit_of_measurement: "lx"
+      - component: "binary_sensor"
+        name: "hem_north"
+        config:
+          state_topic: "ID2"
+          value_template: >-
+            {% if value_json.HEM == 0 %}ON{% else %}OFF{% endif %}
+      - component: "sensor"
+        name: "hemisphere"
+        config:
+          state_topic: "ID2"
+          value_template: >-
+            {% if value_json.HEM == 0 %}North{% else %}South{% endif %}
+    0x03:
+      device_config:
+        command: "ID"
+        channel: "ID"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "date"
+        config:
+          state_topic: "ID3"
+          value_template: >-
+            {% set d=strptime((value_json.DY|int(default=0) ~ '-' ~ value_json.MTH|int(default=0) ~ '-' ~ value_json.YR|int(default=0)),'%d-%m-%Y') %}
+            {{ d.date() }}
+          icon: "mdi:calendar-range"
+      - component: "sensor"
+        name: "date_source"
+        config:
+          state_topic: "ID3"
+          value_template: >-
+            {% if value_json.SRC == 0 %}Real Time Clock{% else %}Radio Waves{% endif %}
+    0x04:
+      device_config:
+        command: "ID"
+        channel: "ID"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "weekday"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {% set map = {"1":"Monday","2":"Tuesday","3":"Wednesday","4":"Thursday","5":"Friday","6":"Saturday","7":"Sunday"} %}
+            {{ map[value_json.WDY|string] }}
+          icon: "mdi:calendar"
+      - component: "sensor"
+        name: "time"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {{ strptime((value_json.HR|int(default=0)~':'~value_json.MIN|int(default=0)~':'~value_json.SEC|int(default=0)),'%H:%M:%S').time() }}
+          icon: "mdi:clock-outline"
+      - component: "sensor"
+        name: "am_pm"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {% if value_json.AMPM == 0 %}AM{% else %}PM{% endif %}
+          icon: "mdi:radio-am"
+      - component: "sensor"
+        name: "time_format"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {% if value_json.TMF == 0 %}24{% else %}12{% endif %}
+      - component: "sensor"
+        name: "time_source"
+        config:
+          state_topic: "ID4"
+          value_template: >-
+            {% if value_json.SRC == 0 %}Real Time Clock{% else %}Radio Waves{% endif %}
+    0x05:
+      device_config:
+        command: "ID"
+        channel: "ID"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "elevation"
+        config:
+          state_topic: "ID5"
+          value_template: "{{ value_json.ELV }}"
+          unit_of_measurement: "°"
+          icon: "mdi:elevation-rise"
+      - component: "sensor"
+        name: "azimuth"
+        config:
+          state_topic: "ID5"
+          value_template: "{{ value_json.AZM }}"
+          unit_of_measurement: "°"
+          icon: "mdi:sun-compass"
+    0x06:
+      device_config:
+        command: "ID"
+        channel: "ID"
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "latitude"
+        config:
+          state_topic: "ID6"
+          value_template: "{{ (value_json.LAT_MSB*256+value_json.LAT_LSB)*180/4095-90 }}"
+          unit_of_measurement: "°"
+          icon: "mdi:latitude"
+      - component: "sensor"
+        name: "longitude"
+        config:
+          state_topic: "ID6"
+          value_template: "{{ (value_json.LOT_MSB*256+value_json.LOT_LSB)*360/4095-180 }}"
+          unit_of_measurement: "°"
+          icon: "mdi:longitude"
+  0x14:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          unit_of_measurement: "V"
+          state_class: "measurement"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: binary_sensor
+        name: "contact"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.CT == 0 %}OFF{% else %}ON{% endif %}
+          device_class: "window"
+    0x09:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          unit_of_measurement: "V"
+          state_class: "measurement"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: binary_sensor
+        name: "state_2p"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.CT == 0 %}OFF{% else %}ON{% endif %}
+          device_class: "window"
+      - component: sensor
+        name: "state_3p"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.CT == 0 %}closed{% elif value_json.CT == 1 %}tilt{% elif value_json.CT == 3 %}open{% else %}reserved{% endif %}
+    0x0A:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "v_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC }}"
+          device_class: "voltage"
+          unit_of_measurement: "V"
+          state_class: "measurement"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "voltage"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.SVC | round(2) }}"
+          device_class: "voltage"
+          state_class: "measurement"
+          unit_of_measurement: "V"
+      - component: binary_sensor
+        name: "state_2p"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.CT == 0 %}OFF{% else %}ON{% endif %}
+          device_class: "window"
+      - component: sensor
+        name: "state_3p"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.CT == 0 %}closed{% elif value_json.CT == 1 %}tilt{% elif value_json.CT == 3 %}open{% else %}reserved{% endif %}
+      - component: binary_sensor
+        name: "vib"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.VIB == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "vibration"
+  0x20:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: "1"
+        answer: "1"
+      entities:
+      - component: "sensor"
+        name: "curval"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.CV }}"
+          unit_of_measurement: "%"
+          icon: "mdi:valve"
+      - component: "binary_sensor"
+        name: "SO"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.SO == 1 %}ON{% else %}OFF{% endif %}
+      - component: "binary_sensor"
+        name: "ENIE"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.ENIE == 1 %}ON{% else %}OFF{% endif %}
+      - component: "binary_sensor"
+        name: "ES"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.ES == 1 %}ON{% else %}OFF{% endif %}
+      - component: "binary_sensor"
+        name: "BCAP"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.BCAP == 1 %}OFF{% else %}ON{% endif %}
+          device_class: "battery"
+      - component: "binary_sensor"
+        name: "CCO"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.CCO == 1 %}ON{% else %}OFF{% endif %}
+      - component: "binary_sensor"
+        name: "FTS"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FTS == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "problem"
+      - component: "binary_sensor"
+        name: "DWO"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.DWO == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "window"
+      - component: "binary_sensor"
+        name: "ACO"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.ACO == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "problem"
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "number"
+        name: "config_valve_position"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "100"
+          step: "1"
+          mode: "slider"
+          unit_of_measurement: "%"
+          icon: "mdi:valve"
+      - component: "number"
+        name: "config_t_setpoint"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "40"
+          step: "0.25"
+          mode: "slider"
+          unit_of_measurement: "°C"
+          icon: "mdi:thermometer"
+      - component: "number"
+        name: "config_t_RCU"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "40"
+          step: "0.25"
+          mode: "slider"
+          unit_of_measurement: "°C"
+          icon: "mdi:thermometer"
+      - component: "switch"
+        name: "config_RIN"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_LFS"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_VO"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_VC"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_SB"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_SPS"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_SPN"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_RCU"
+        config:
+          command_topic: "__trash"
+      - component: "button"
+        name: "set_config"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('config_valve_position',ignorecase=True) %}
+                {% set ns.valve_position = (states(entity)|int(default=0)) %}
+              {% elif entity is search('config_t_setpoint',ignorecase=True) %}
+                {% set ns.temperature_setpoint = ((states(entity)|int(default=0))*255/40)|int %}
+              {% elif entity is search('config_t_RCU',ignorecase=True) %}
+                {% set ns.TMP = (states(entity)|float(default=0.0)) %}
+              {% elif entity is search('config_RIN',ignorecase=True) %}
+                {% set ns.RIN = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_LFS',ignorecase=True) %}
+                {% set ns.LFS = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_SPS',ignorecase=True) %}
+                {% set ns.SPS = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_SPN',ignorecase=True) %}
+                {% set ns.SPN = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_RCU',ignorecase=True) %}
+                {% set ns.RCU = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_VO',ignorecase=True) %}
+                {% set ns.VO = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_VC',ignorecase=True) %}
+                {% set ns.VC = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_SB',ignorecase=True) %}
+                {% set ns.SB = iif(is_state(entity, "on"), 1, 0) %}
+              {% endif %}
+            {% endfor %}
+            {% set ns.SP = iif((ns.SPS == 1), ns.temperature_setpoint, ns.valve_position) %}
+            {"SP":{{ns.SP}},"TMP":{{ns.TMP}},"RIN":{{ns.RIN}},"LFS":{{ns.LFS}},"VO":{{ns.VO}},"VC":{{ns.VC}},"SB":{{ns.SB}},"SPS":{{ns.SPS}},"SPN":{{ns.SPN}},"RCU":{{ns.RCU}}}
+          icon: "mdi:download"
+    0x04:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: "1"
+        answer: "1"
+      entities:
+      - component: "sensor"
+        name: "curval"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.CP }}"
+          unit_of_measurement: "%"
+          icon: "mdi:valve"
+      - component: "sensor"
+        name: "ft_raw"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TS == 0 %}
+              {{ value_json.FTS * 60 / 255 + 20 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "feed_temperature"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TS == 0 %}
+              {{ (value_json.FTS * 60 / 255 + 20) | round(1) }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "st_raw"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TS == 1 %}
+              {{ value_json.FTS * 20 / 255 + 10 }}
+            {% endif %}
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "setpoint_temperature"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TS == 1 %}
+              {{ (value_json.FTS * 20 / 255 + 10) | round(1) }}
+            {% endif %}
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "rt_raw"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FL == 0 %}
+              {{ value_json.TMPFC * 20 / 255 + 10 }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+          device_class: "temperature"
+          unit_of_measurement: "°C"
+          state_class: "measurement"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "room_temperature"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FL == 0 %}
+              {{ (value_json.TMPFC * 20 / 255 + 10) | round(1) }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "binary_sensor"
+        name: "err_meas"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FL == 1 %}
+              {% if value_json.TMPFC == 17 %}ON{% else %}OFF{% endif %}
+            {% else %}
+              {{ states(entity_id) }}
+            {% endif %}
+          device_class: "problem"
+      - component: "binary_sensor"
+        name: "battery"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FL == 1 %}
+              {% if value_json.TMPFC == 18 %}ON{% else %}OFF{% endif %}
+            {% else %}
+              {{ states(entity_id) }}
+            {% endif %}
+          device_class: "battery"
+      - component: "binary_sensor"
+        name: "err_frost_prot"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FL == 1 %}
+              {% if value_json.TMPFC == 20 %}ON{% else %}OFF{% endif %}
+            {% else %}
+              {{ states(entity_id) }}
+            {% endif %}
+          device_class: "problem"
+      - component: "binary_sensor"
+        name: "err_blocked_valve"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FL == 1 %}
+              {% if value_json.TMPFC == 33 %}ON{% else %}OFF{% endif %}
+            {% else %}
+              {{ states(entity_id) }}
+            {% endif %}
+          device_class: "problem"
+      - component: "binary_sensor"
+        name: "err_endpoint"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FL == 1 %}
+              {% if value_json.TMPFC == 36 %}ON{% else %}OFF{% endif %}
+            {% else %}
+              {{ states(entity_id) }}
+            {% endif %}
+          device_class: "problem"
+      - component: "binary_sensor"
+        name: "err_novalve"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FL == 1 %}
+              {% if value_json.TMPFC == 40 %}ON{% else %}OFF{% endif %}
+            {% else %}
+              {{ states(entity_id) }}
+            {% endif %}
+          device_class: "problem"
             # The other errors are not related to the valve itself,
             # so may be it is sufficient to only raise a flag
-            - component: "binary_sensor"
-              name: "failure"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.FL == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "problem"
-            - component: "number"
-              name: "config_position"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "100"
-                 step: "1"
-                 mode: "slider"
-                 unit_of_measurement: "%"
-                 icon: "mdi:valve"
-            - component: "number"
-              name: "config_TSP"
-              config:
-                 command_topic: "__trash"
-                 min: "10"
-                 max: "30"
-                 step: "0.25"
-                 mode: "slider"
-                 unit_of_measurement: "°C"
-                 icon: "mdi:thermometer"
-            - component: "switch"
-              name: "config_MC"
-              config:
-                 command_topic: "__trash"
-            - component: "select"
-              name: "config_wakeup_time"
-              config:
-                 options:
-                    - "0 - 10 sec"
-                    - "1 - 60 sec"
-                    - "2 - 90 sec"
-                    - "3 - 120 sec"
-                    - "4 - 150 sec"
-                    - "5 - 180 sec"
-                    - "6 - 210 sec"
-                    - "7 - 240 sec"
-                    - "8 - 270 sec"
-                    - "9 - 300 sec"
-                    - "10 - 330 sec"
-                    - "11 - 360 sec"
-                    - "12 - 390 sec"
-                    - "13 - 420 sec"
-                    - "14 - 450 sec"
-                    - "15 - 480 sec"
-                    - "16 - 510 sec"
-                    - "17 - 540 sec"
-                    - "18 - 570 sec"
-                    - "19 - 600 sec"
-                    - "20 - 630 sec"
-                    - "21 - 660 sec"
-                    - "22 - 690 sec"
-                    - "23 - 720 sec"
-                    - "24 - 750 sec"
-                    - "25 - 780 sec"
-                    - "26 - 810 sec"
-                    - "27 - 840 sec"
-                    - "28 - 870 sec"
-                    - "29 - 900 sec"
-                    - "30 - 930 sec"
-                    - "31 - 960 sec"
-                    - "32 - 990 sec"
-                    - "33 - 1020 sec"
-                    - "34 - 1050 sec"
-                    - "35 - 1080 sec"
-                    - "36 - 1110 sec"
-                    - "37 - 1140 sec"
-                    - "38 - 1170 sec"
-                    - "39 - 1200 sec"
-                    - "40 - 1230 sec"
-                    - "41 - 1260 sec"
-                    - "42 - 1290 sec"
-                    - "43 - 1320 sec"
-                    - "44 - 1350 sec"
-                    - "45 - 1380 sec"
-                    - "46 - 1410 sec"
-                    - "47 - 1440 sec"
-                    - "48 - 1470 sec"
-                    - "49 - 1500 sec"
-                    - "50 - 3 hrs"
-                    - "51 - 6 hrs"
-                    - "52 - 9 hrs"
-                    - "53 - 12 hrs"
-                    - "54 - 15 hrs"
-                    - "55 - 18 hrs"
-                    - "56 - 21 hrs"
-                    - "57 - 24 hrs"
-                    - "58 - 27 hrs"
-                    - "59 - 30 hrs"
-                    - "60 - 33 hrs"
-                    - "61 - 36 hrs"
-                    - "62 - 39 hrs"
-                    - "63 - 42 hrs (max)"
-                 command_topic: "__trash"
-            - component: "select"
-              name: "config_DSO"
-              config:
-                 options:
-                    - "0°"
-                    - "90°"
-                    - "180°"
-                    - "270°"
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_BLC"
-              config:
-                 command_topic: "__trash"
-            - component: "select"
-              name: "config_SER"
-              config:
-                 options:
-                    - "0 - No change"
-                    - "1 - Open valve"
-                    - "2 - Run initialization"
-                    - "3 - Close valve"
-                 command_topic: "__trash"
-            - component: "button"
-              name: "set_config"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('config_position',ignorecase=True) %}
-                       {% set ns.POS = (states(entity)|int(default=0)) %}
-                     {% elif entity is search('config_TSP',ignorecase=True) %}
-                       {% set ns.TSP = (states(entity)|float(default=0.0)) %}
-                     {% elif entity is search('config_wakeup_time',ignorecase=True) %}
-                       {% set ns.WUC = states(entity).split("-")[0]|int(default=0) %}
-                     {% elif entity is search('config_DSO',ignorecase=True) %}
-                       {% set ns.DSO = (states(entity).split("°")[0]|int(default=0)/90) %}
-                     {% elif entity is search('config_BLC',ignorecase=True) %}
-                       {% set ns.BLC = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_SER',ignorecase=True) %}
-                       {% set ns.SER = states(entity).split("-")[0]|int(default=0) %}
-                     {% elif entity is search('config_MC',ignorecase=True) %}
-                       {% set ns.MC = iif(is_state(entity, "on"), 1, 0) %}
-                     {% endif %}
-                   {% endfor %}
-                   {"POS":{{ns.POS}},"TSP":{{ns.TSP}},"MC":{{ns.MC}},"WUC":{{ns.WUC}},"DSO":{{ns.DSO}},"BLC":{{ns.BLC}},"SER":{{ns.SER}}}
-                 icon: "mdi:download"
-      0x06:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: "1"
-            answer: "1"
-         entities:
-            - component: "sensor"
-              name: "curval"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.CV }}"
-                 unit_of_measurement: "%"
-                 icon: "mdi:valve"
-            - component: "sensor"
-              name: "feed_temperature"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TSL == 1 %}
-                     {{ ((value_json.TMP|float(default=0))*0.5) | round(1) }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "setpoint_temperature"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.LOM == 1 %}
-                     {{ ((value_json.LO|float(default=0))*0.5) | round(1) }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "local_offset"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.LOM == 0 %}
-                     {% if value_json.LO|int(default=0) > 63 %}
-                       {{ ((value_json.LO|int(default=0)-128)) }}
-                     {% else %}
-                       {{ value_json.LO|int(default=0) }}
-                     {% endif %}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-                 device_class: "temperature"
-                 unit_of_measurement: "°C"
-            - component: "sensor"
-              name: "room_temperature"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TSL == 0 %}
-                     {{ ((value_json.TMP|float(default=0))*0.5) | round(1) }}
-                   {% else %}
-                     {{ states(entity_id)|int(default=0) }}
-                   {% endif %}
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: "binary_sensor"
-              name: "LOM"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.LOM == 1 %}ON{% else %}OFF{% endif %}
-            - component: "binary_sensor"
-              name: "TSL"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.TSL == 1 %}ON{% else %}OFF{% endif %}
-            - component: "binary_sensor"
-              name: "ENIE"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.ENIE == 1 %}ON{% else %}OFF{% endif %}
-            - component: "binary_sensor"
-              name: "ES"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.ES == 1 %}OFF{% else %}ON{% endif %}
-                 device_class: "battery"
-            - component: "binary_sensor"
-              name: "DWO"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.DWO == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "window"
-            - component: "binary_sensor"
-              name: "RCE"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.RCE == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "problem"
-            - component: "binary_sensor"
-              name: "RSS"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.RSS == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "problem"
-            - component: "binary_sensor"
-              name: "ACO"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.ACO == 1 %}ON{% else %}OFF{% endif %}
-                 device_class: "problem"
-            - component: "number"
-              name: "config_valve_position"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "100"
-                 step: "1"
-                 mode: "slider"
-                 unit_of_measurement: "%"
-                 icon: "mdi:valve"
-            - component: "number"
-              name: "config_temperature_setpoint"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "40"
-                 step: "0.5"
-                 mode: "slider"
-                 unit_of_measurement: "°C"
-                 icon: "mdi:thermometer"
-            - component: "number"
-              name: "config_temperature_RCU"
-              config:
-                 command_topic: "__trash"
-                 min: "0"
-                 max: "40"
-                 step: "0.25"
-                 mode: "slider"
-                 unit_of_measurement: "°C"
-                 icon: "mdi:thermometer"
-            - component: "switch"
-              name: "config_REF"
-              config:
-                 command_topic: "__trash"
-            - component: "select"
-              name: "config_RFC"
-              config:
-                 options:
-                    - "AUTO (default) 2, 5 or 10 minutes"
-                    - "2 minutes"
-                    - "5 minutes"
-                    - "10 minutes"
-                    - "20 minutes"
-                    - "30 minutes"
-                    - "60 minutes"
-                    - "120 minutes"
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_SB"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_SPS"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_TSL"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "config_SBY"
-              config:
-                 command_topic: "__trash"
-            - component: "button"
-              name: "set_config"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace() %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('config_valve_position',ignorecase=True) %}
-                       {% set ns.valve_position = (states(entity)|int(default=0)) %}
-                     {% elif entity is search('config_temperature_setpoint',ignorecase=True) %}
-                       {% set ns.temperature_setpoint = ((states(entity)|int(default=0))*2) %}
-                     {% elif entity is search('config_temperature_RCU',ignorecase=True) %}
-                       {% set ns.TMP = ((states(entity)|float(default=0.0))) %}
-                     {% elif entity is search('config_REF',ignorecase=True) %}
-                       {% set ns.REF = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_RFC',ignorecase=True) %}
-                       {% set map = {"0": 0, "2": 1, "5": 2, "10": 3, "20": 4, "30": 5, "60": 6, "120": 7} %}
-                       {% set ns.RFC = map[states(entity).split(" ")[0]|int(default=0)|string] %}
-                     {% elif entity is search('config_SBY',ignorecase=True) %}
-                       {% set ns.SBY = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_SPS',ignorecase=True) %}
-                       {% set ns.SPS = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_TSL',ignorecase=True) %}
-                       {% set ns.TSL = iif(is_state(entity, "on"), 1, 0) %}
-                     {% elif entity is search('config_SB',ignorecase=True) %}
-                       {% set ns.SB = iif(is_state(entity, "on"), 1, 0) %}
-                     {% endif %}
-                   {% endfor %}
-                   {% set ns.SP = iif((ns.SPS == 1), ns.temperature_setpoint, ns.valve_position) %}
-                   {"SP":{{ns.SP}},"TMP":{{ns.TMP}},"REF":{{ns.REF}},"RFC":{{ns.RFC}},"SB":{{ns.SB}},"SPS":{{ns.SPS}},"TSL":{{ns.TSL}},"SBY":{{ns.SBY}}}
-                 icon: "mdi:download"
-   0x30:
-      0x02:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: binary_sensor
-              name: "Input_State"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.IPS }}"
-                 payload_on: "0"
-                 payload_off: "1"
-      0x03:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "t_raw"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-                 enabled_by_default: "false"
-            - component: "sensor"
-              name: "tempC"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.TMP | round(1) }}"
-                 device_class: "temperature"
-                 state_class: "measurement"
-                 unit_of_measurement: "°C"
-            - component: binary_sensor
-              name: "wake"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.WA0 == 0 %}OFF{% else %}ON{% endif %}
-            - component: binary_sensor
-              name: "DI3"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.DI3 == 0 %}OFF{% else %}ON{% endif %}
-            - component: binary_sensor
-              name: "DI2"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.DI2 == 0 %}OFF{% else %}ON{% endif %}
-            - component: binary_sensor
-              name: "DI1"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.DI1 == 0 %}OFF{% else %}ON{% endif %}
-            - component: binary_sensor
-              name: "DI0"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.DI0 == 0 %}OFF{% else %}ON{% endif %}
-      0x04:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "sensor"
-              name: "value"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.DV0 }}"
-            - component: binary_sensor
-              name: "DI2"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.DI2 == 0 %}OFF{% else %}ON{% endif %}
-            - component: binary_sensor
-              name: "DI1"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.DI1 == 0 %}OFF{% else %}ON{% endif %}
-            - component: binary_sensor
-              name: "DI0"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.DI0 == 0 %}OFF{% else %}ON{% endif %}
-   0x38:
-      0x08:
-         device_config:
-            command: "COM"
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: "switch"
-              name: "switch_COM1"
-              config:
-                 command_topic: "req"
-                 payload_on: >
-                   {"COM":"1","TIM":"0","LCK":"0","DEL":"0","SW":"1","send":"clear"}
-                 payload_off: >
-                   {"COM":"1","TIM":"0","LCK":"0","DEL":"0","SW":"0","send":"clear"}
-                 device_class: outlet
-                 enabled_by_default: "false"
-            - component: "light"
-              name: "light_COM1"
-              config:
-                 schema: "template"
-                 command_topic: "req"
-                 command_on_template: >-
-                   {"COM":"1","TIM":"0","LCK":"0","DEL":"0","SW":"1","send":"clear"}
-                 command_off_template: >-
-                   {"COM":"1","TIM":"0","LCK":"0","DEL":"0","SW":"0","send":"clear"}
-            - component: "light"
-              name: "light_COM2"
-              config:
-                 schema: "template"
-                 command_topic: "req"
-                 payload_press: >-
-                   {"send":"clear"}
-            - component: "light"
-              name: "light_COM2"
-              config:
-                 schema: "template"
-                 command_topic: "req"
-                 command_on_template: >-
-                   {"COM":"2","EDIM":"100","RMP":"1","EDIMR":"0","STR":"0","SW":"1","send":"clear"}
-                 command_off_template: >-
-                   {"COM":"2","EDIM":"0","RMP":"1","EDIMR":"0","STR":"0","SW":"0","send":"clear"}
+      - component: "binary_sensor"
+        name: "failure"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.FL == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "problem"
+      - component: "number"
+        name: "config_position"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "100"
+          step: "1"
+          mode: "slider"
+          unit_of_measurement: "%"
+          icon: "mdi:valve"
+      - component: "number"
+        name: "config_TSP"
+        config:
+          command_topic: "__trash"
+          min: "10"
+          max: "30"
+          step: "0.25"
+          mode: "slider"
+          unit_of_measurement: "°C"
+          icon: "mdi:thermometer"
+      - component: "switch"
+        name: "config_MC"
+        config:
+          command_topic: "__trash"
+      - component: "select"
+        name: "config_wakeup_time"
+        config:
+          options:
+          - "0 - 10 sec"
+          - "1 - 60 sec"
+          - "2 - 90 sec"
+          - "3 - 120 sec"
+          - "4 - 150 sec"
+          - "5 - 180 sec"
+          - "6 - 210 sec"
+          - "7 - 240 sec"
+          - "8 - 270 sec"
+          - "9 - 300 sec"
+          - "10 - 330 sec"
+          - "11 - 360 sec"
+          - "12 - 390 sec"
+          - "13 - 420 sec"
+          - "14 - 450 sec"
+          - "15 - 480 sec"
+          - "16 - 510 sec"
+          - "17 - 540 sec"
+          - "18 - 570 sec"
+          - "19 - 600 sec"
+          - "20 - 630 sec"
+          - "21 - 660 sec"
+          - "22 - 690 sec"
+          - "23 - 720 sec"
+          - "24 - 750 sec"
+          - "25 - 780 sec"
+          - "26 - 810 sec"
+          - "27 - 840 sec"
+          - "28 - 870 sec"
+          - "29 - 900 sec"
+          - "30 - 930 sec"
+          - "31 - 960 sec"
+          - "32 - 990 sec"
+          - "33 - 1020 sec"
+          - "34 - 1050 sec"
+          - "35 - 1080 sec"
+          - "36 - 1110 sec"
+          - "37 - 1140 sec"
+          - "38 - 1170 sec"
+          - "39 - 1200 sec"
+          - "40 - 1230 sec"
+          - "41 - 1260 sec"
+          - "42 - 1290 sec"
+          - "43 - 1320 sec"
+          - "44 - 1350 sec"
+          - "45 - 1380 sec"
+          - "46 - 1410 sec"
+          - "47 - 1440 sec"
+          - "48 - 1470 sec"
+          - "49 - 1500 sec"
+          - "50 - 3 hrs"
+          - "51 - 6 hrs"
+          - "52 - 9 hrs"
+          - "53 - 12 hrs"
+          - "54 - 15 hrs"
+          - "55 - 18 hrs"
+          - "56 - 21 hrs"
+          - "57 - 24 hrs"
+          - "58 - 27 hrs"
+          - "59 - 30 hrs"
+          - "60 - 33 hrs"
+          - "61 - 36 hrs"
+          - "62 - 39 hrs"
+          - "63 - 42 hrs (max)"
+          command_topic: "__trash"
+      - component: "select"
+        name: "config_DSO"
+        config:
+          options:
+          - "0°"
+          - "90°"
+          - "180°"
+          - "270°"
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_BLC"
+        config:
+          command_topic: "__trash"
+      - component: "select"
+        name: "config_SER"
+        config:
+          options:
+          - "0 - No change"
+          - "1 - Open valve"
+          - "2 - Run initialization"
+          - "3 - Close valve"
+          command_topic: "__trash"
+      - component: "button"
+        name: "set_config"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('config_position',ignorecase=True) %}
+                {% set ns.POS = (states(entity)|int(default=0)) %}
+              {% elif entity is search('config_TSP',ignorecase=True) %}
+                {% set ns.TSP = (states(entity)|float(default=0.0)) %}
+              {% elif entity is search('config_wakeup_time',ignorecase=True) %}
+                {% set ns.WUC = states(entity).split("-")[0]|int(default=0) %}
+              {% elif entity is search('config_DSO',ignorecase=True) %}
+                {% set ns.DSO = (states(entity).split("°")[0]|int(default=0)/90) %}
+              {% elif entity is search('config_BLC',ignorecase=True) %}
+                {% set ns.BLC = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_SER',ignorecase=True) %}
+                {% set ns.SER = states(entity).split("-")[0]|int(default=0) %}
+              {% elif entity is search('config_MC',ignorecase=True) %}
+                {% set ns.MC = iif(is_state(entity, "on"), 1, 0) %}
+              {% endif %}
+            {% endfor %}
+            {"POS":{{ns.POS}},"TSP":{{ns.TSP}},"MC":{{ns.MC}},"WUC":{{ns.WUC}},"DSO":{{ns.DSO}},"BLC":{{ns.BLC}},"SER":{{ns.SER}}}
+          icon: "mdi:download"
+    0x06:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: "1"
+        answer: "1"
+      entities:
+      - component: "sensor"
+        name: "curval"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.CV }}"
+          unit_of_measurement: "%"
+          icon: "mdi:valve"
+      - component: "sensor"
+        name: "feed_temperature"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TSL == 1 %}
+              {{ ((value_json.TMP|float(default=0))*0.5) | round(1) }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "setpoint_temperature"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.LOM == 1 %}
+              {{ ((value_json.LO|float(default=0))*0.5) | round(1) }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "local_offset"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.LOM == 0 %}
+              {% if value_json.LO|int(default=0) > 63 %}
+                {{ ((value_json.LO|int(default=0)-128)) }}
+              {% else %}
+                {{ value_json.LO|int(default=0) }}
+              {% endif %}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+          device_class: "temperature"
+          unit_of_measurement: "°C"
+      - component: "sensor"
+        name: "room_temperature"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TSL == 0 %}
+              {{ ((value_json.TMP|float(default=0))*0.5) | round(1) }}
+            {% else %}
+              {{ states(entity_id)|int(default=0) }}
+            {% endif %}
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: "binary_sensor"
+        name: "LOM"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.LOM == 1 %}ON{% else %}OFF{% endif %}
+      - component: "binary_sensor"
+        name: "TSL"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.TSL == 1 %}ON{% else %}OFF{% endif %}
+      - component: "binary_sensor"
+        name: "ENIE"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.ENIE == 1 %}ON{% else %}OFF{% endif %}
+      - component: "binary_sensor"
+        name: "ES"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.ES == 1 %}OFF{% else %}ON{% endif %}
+          device_class: "battery"
+      - component: "binary_sensor"
+        name: "DWO"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.DWO == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "window"
+      - component: "binary_sensor"
+        name: "RCE"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.RCE == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "problem"
+      - component: "binary_sensor"
+        name: "RSS"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.RSS == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "problem"
+      - component: "binary_sensor"
+        name: "ACO"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.ACO == 1 %}ON{% else %}OFF{% endif %}
+          device_class: "problem"
+      - component: "number"
+        name: "config_valve_position"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "100"
+          step: "1"
+          mode: "slider"
+          unit_of_measurement: "%"
+          icon: "mdi:valve"
+      - component: "number"
+        name: "config_temperature_setpoint"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "40"
+          step: "0.5"
+          mode: "slider"
+          unit_of_measurement: "°C"
+          icon: "mdi:thermometer"
+      - component: "number"
+        name: "config_temperature_RCU"
+        config:
+          command_topic: "__trash"
+          min: "0"
+          max: "40"
+          step: "0.25"
+          mode: "slider"
+          unit_of_measurement: "°C"
+          icon: "mdi:thermometer"
+      - component: "switch"
+        name: "config_REF"
+        config:
+          command_topic: "__trash"
+      - component: "select"
+        name: "config_RFC"
+        config:
+          options:
+          - "AUTO (default) 2, 5 or 10 minutes"
+          - "2 minutes"
+          - "5 minutes"
+          - "10 minutes"
+          - "20 minutes"
+          - "30 minutes"
+          - "60 minutes"
+          - "120 minutes"
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_SB"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_SPS"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_TSL"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "config_SBY"
+        config:
+          command_topic: "__trash"
+      - component: "button"
+        name: "set_config"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace() %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('config_valve_position',ignorecase=True) %}
+                {% set ns.valve_position = (states(entity)|int(default=0)) %}
+              {% elif entity is search('config_temperature_setpoint',ignorecase=True) %}
+                {% set ns.temperature_setpoint = ((states(entity)|int(default=0))*2) %}
+              {% elif entity is search('config_temperature_RCU',ignorecase=True) %}
+                {% set ns.TMP = ((states(entity)|float(default=0.0))) %}
+              {% elif entity is search('config_REF',ignorecase=True) %}
+                {% set ns.REF = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_RFC',ignorecase=True) %}
+                {% set map = {"0": 0, "2": 1, "5": 2, "10": 3, "20": 4, "30": 5, "60": 6, "120": 7} %}
+                {% set ns.RFC = map[states(entity).split(" ")[0]|int(default=0)|string] %}
+              {% elif entity is search('config_SBY',ignorecase=True) %}
+                {% set ns.SBY = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_SPS',ignorecase=True) %}
+                {% set ns.SPS = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_TSL',ignorecase=True) %}
+                {% set ns.TSL = iif(is_state(entity, "on"), 1, 0) %}
+              {% elif entity is search('config_SB',ignorecase=True) %}
+                {% set ns.SB = iif(is_state(entity, "on"), 1, 0) %}
+              {% endif %}
+            {% endfor %}
+            {% set ns.SP = iif((ns.SPS == 1), ns.temperature_setpoint, ns.valve_position) %}
+            {"SP":{{ns.SP}},"TMP":{{ns.TMP}},"REF":{{ns.REF}},"RFC":{{ns.RFC}},"SB":{{ns.SB}},"SPS":{{ns.SPS}},"TSL":{{ns.TSL}},"SBY":{{ns.SBY}}}
+          icon: "mdi:download"
+  0x30:
+    0x02:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: binary_sensor
+        name: "Input_State"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.IPS }}"
+          payload_on: "0"
+          payload_off: "1"
+    0x03:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "t_raw"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+          enabled_by_default: "false"
+      - component: "sensor"
+        name: "tempC"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.TMP | round(1) }}"
+          device_class: "temperature"
+          state_class: "measurement"
+          unit_of_measurement: "°C"
+      - component: binary_sensor
+        name: "wake"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.WA0 == 0 %}OFF{% else %}ON{% endif %}
+      - component: binary_sensor
+        name: "DI3"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.DI3 == 0 %}OFF{% else %}ON{% endif %}
+      - component: binary_sensor
+        name: "DI2"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.DI2 == 0 %}OFF{% else %}ON{% endif %}
+      - component: binary_sensor
+        name: "DI1"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.DI1 == 0 %}OFF{% else %}ON{% endif %}
+      - component: binary_sensor
+        name: "DI0"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.DI0 == 0 %}OFF{% else %}ON{% endif %}
+    0x04:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "sensor"
+        name: "value"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.DV0 }}"
+      - component: binary_sensor
+        name: "DI2"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.DI2 == 0 %}OFF{% else %}ON{% endif %}
+      - component: binary_sensor
+        name: "DI1"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.DI1 == 0 %}OFF{% else %}ON{% endif %}
+      - component: binary_sensor
+        name: "DI0"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.DI0 == 0 %}OFF{% else %}ON{% endif %}
+  0x38:
+    0x08:
+      device_config:
+        command: "COM"
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: "switch"
+        name: "switch_COM1"
+        config:
+          command_topic: "req"
+          payload_on: >
+            {"COM":"1","TIM":"0","LCK":"0","DEL":"0","SW":"1","send":"clear"}
+          payload_off: >
+            {"COM":"1","TIM":"0","LCK":"0","DEL":"0","SW":"0","send":"clear"}
+          device_class: outlet
+          enabled_by_default: "false"
+      - component: "light"
+        name: "light_COM1"
+        config:
+          schema: "template"
+          command_topic: "req"
+          command_on_template: >-
+            {"COM":"1","TIM":"0","LCK":"0","DEL":"0","SW":"1","send":"clear"}
+          command_off_template: >-
+            {"COM":"1","TIM":"0","LCK":"0","DEL":"0","SW":"0","send":"clear"}
+      - component: "light"
+        name: "light_COM2"
+        config:
+          schema: "template"
+          command_topic: "req"
+          payload_press: >-
+            {"send":"clear"}
+      - component: "light"
+        name: "light_COM2"
+        config:
+          schema: "template"
+          command_topic: "req"
+          command_on_template: >-
+            {"COM":"2","EDIM":"100","RMP":"1","EDIMR":"0","STR":"0","SW":"1","send":"clear"}
+          command_off_template: >-
+            {"COM":"2","EDIM":"0","RMP":"1","EDIMR":"0","STR":"0","SW":"0","send":"clear"}
 0xF6:
-   0x02:
-      0x01: &F60201
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-            persistent: false
-         entities:
-            - component: binary_sensor
-              name: "pressed"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.EB }}"
-                 payload_on: "1"
-                 payload_off: "0"
-            - component: binary_sensor
-              name: "AI_pressed"
-              config:
-                 state_topic: ""
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                   {% if (value_json.EB and value_json.R1 == 0) or (value_json.SA and value_json.R2 == 0) %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "AO_pressed"
-              config:
-                 state_topic: ""
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                   {% if (value_json.EB and value_json.R1 == 1) or (value_json.SA and value_json.R2 == 1) %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "BI_pressed"
-              config:
-                 state_topic: ""
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                   {% if (value_json.EB and value_json.R1 == 2) or (value_json.SA and value_json.R2 == 2) %}on{% else %}off{% endif %}
-            - component: binary_sensor
-              name: "BO_pressed"
-              config:
-                 state_topic: ""
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                   {% if (value_json.EB and value_json.R1 == 3) or (value_json.SA and value_json.R2 == 3) %}on{% else %}off{% endif %}
-         virtual:
-            - component: select
-              name: "action"
-              config:
-                 options:
-                    - "None"
-                    - "AO"
-                    - "AI"
-                    - "BO"
-                    - "BI"
-                    - "AO + BO"
-                    - "AO + BI"
-                    - "AI + BO"
-                    - "AI + BI"
-                    - "BO + AO"
-                    - "BO + AI"
-                    - "BI + AO"
-                    - "BI + AI"
-                 command_topic: "req"
-                 command_template: >-
-                   {% set R1, EB, R2, SA, T21, NU = 0, 0, 0, 0, 1, 0 %}
-                   {% set id = {"AI":"0","AO":"1","BI":"2","BO":"3"} %}
-                   {% set action = value.split(" + ") %}
-                   {% if value is not search('None') %}{% set EB, NU, R1 = 1, 1, id[action[0]] %}{% endif %}
-                   {% if action|length==2 %}{% set SA, R2 = 1, id[action[1]] %}{% endif %}
-                   {"R1":{{R1}},"EB":{{EB}},"R2":{{R2}},"SA":{{SA}},"T21":{{T21}},"NU":{{NU}},"send":"clear"}
-            - component: "switch"
-              name: "AI"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "AO"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "BI"
-              config:
-                 command_topic: "__trash"
-            - component: "switch"
-              name: "BO"
-              config:
-                 command_topic: "__trash"
-            - component: "button"
-              name: "send"
-              config:
-                 command_topic: "req"
-                 command_template: >-
-                   {% set ns = namespace(action=[]) %}
-                   {% for entity in device_entities(device_id(entity_id)) %}
-                     {% if entity is search('AI',ignorecase=True) and is_state(entity, "on") %}
-                       {% set ns.action = ns.action+["0"] %}
-                     {% elif entity is search('AO',ignorecase=True) and is_state(entity, "on") %}
-                       {% set ns.action = ns.action+["1"] %}
-                     {% elif entity is search('BI',ignorecase=True) and is_state(entity, "on") %}
-                       {% set ns.action = ns.action+["2"] %}
-                     {% elif entity is search('BO',ignorecase=True) and is_state(entity, "on") %}
-                       {% set ns.action = ns.action+["3"] %}
-                     {% endif %}
-                   {% endfor %}
-                   {% set R1, EB, R2, SA, T21, NU = 0, 0, 0, 0, 1, 0 %}
-                   {% if ns.action|length>0 %}{% set EB, NU, R1 = 1, 1, ns.action[0] %}{% endif %}
-                   {% if ns.action|length>1 %}{% set SA, R2 = 1, ns.action[1] %}{% endif %}
-                   {"R1":{{R1}},"EB":{{EB}},"R2":{{R2}},"SA":{{SA}},"T21":{{T21}},"NU":{{NU}},"send":"clear"}
-                 icon: "mdi:download"
-      0x02: *F60201
-   0x04:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: binary_sensor
-              name: "status"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.KC == 112 %}ON{% else %}OFF{% endif %}
-   0x05:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-            persistent: "false"
-         entities:
-            - component: "device_automation"
-              name: "trig_water"
-              config:
-                 automation_type: "trigger"
-                 type: "water_detected"
-                 subtype: "sensor"
-                 topic: ""
-                 payload: "17"
-                 value_template: "{{ value_json.WAS }}"
-      0x02:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: binary_sensor
-              name: "alarm"
-              config:
-                 state_topic: ""
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                   {% if value_json.SMO == 16 %}on{% else %}off{% endif %}
-                 device_class: smoke
-            - component: binary_sensor
-              name: "battery"
-              config:
-                 state_topic: ""
-                 payload_on: "on"
-                 payload_off: "off"
-                 value_template: >-
-                   {% if value_json.SMO == 48 %}on{% else %}off{% endif %}
-                 device_class: battery
-   0x10:
-      0x00:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: binary_sensor
-              name: "state_2p"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.WIN == 3 %}OFF{% else %}ON{% endif %}
-                 device_class: "window"
-            - component: sensor
-              name: "state_3p"
-              config:
-                 state_topic: ""
-                 value_template: >-
-                   {% if value_json.WIN == 3 %}off{% elif value_json.WIN == 1 %}tilt{% else %}on{% endif %}
+  0x02:
+    0x01: &F60201
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+        persistent: false
+      entities:
+      - component: binary_sensor
+        name: "pressed"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.EB }}"
+          payload_on: "1"
+          payload_off: "0"
+      - component: binary_sensor
+        name: "AI_pressed"
+        config:
+          state_topic: ""
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if (value_json.EB and value_json.R1 == 0) or (value_json.SA and value_json.R2 == 0) %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "AO_pressed"
+        config:
+          state_topic: ""
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if (value_json.EB and value_json.R1 == 1) or (value_json.SA and value_json.R2 == 1) %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "BI_pressed"
+        config:
+          state_topic: ""
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if (value_json.EB and value_json.R1 == 2) or (value_json.SA and value_json.R2 == 2) %}on{% else %}off{% endif %}
+      - component: binary_sensor
+        name: "BO_pressed"
+        config:
+          state_topic: ""
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if (value_json.EB and value_json.R1 == 3) or (value_json.SA and value_json.R2 == 3) %}on{% else %}off{% endif %}
+      virtual:
+      - component: select
+        name: "action"
+        config:
+          options:
+          - "None"
+          - "AO"
+          - "AI"
+          - "BO"
+          - "BI"
+          - "AO + BO"
+          - "AO + BI"
+          - "AI + BO"
+          - "AI + BI"
+          - "BO + AO"
+          - "BO + AI"
+          - "BI + AO"
+          - "BI + AI"
+          command_topic: "req"
+          command_template: >-
+            {% set R1, EB, R2, SA, T21, NU = 0, 0, 0, 0, 1, 0 %}
+            {% set id = {"AI":"0","AO":"1","BI":"2","BO":"3"} %}
+            {% set action = value.split(" + ") %}
+            {% if value is not search('None') %}{% set EB, NU, R1 = 1, 1, id[action[0]] %}{% endif %}
+            {% if action|length==2 %}{% set SA, R2 = 1, id[action[1]] %}{% endif %}
+            {"R1":{{R1}},"EB":{{EB}},"R2":{{R2}},"SA":{{SA}},"T21":{{T21}},"NU":{{NU}},"send":"clear"}
+      - component: "switch"
+        name: "AI"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "AO"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "BI"
+        config:
+          command_topic: "__trash"
+      - component: "switch"
+        name: "BO"
+        config:
+          command_topic: "__trash"
+      - component: "button"
+        name: "send"
+        config:
+          command_topic: "req"
+          command_template: >-
+            {% set ns = namespace(action=[]) %}
+            {% for entity in device_entities(device_id(entity_id)) %}
+              {% if entity is search('AI',ignorecase=True) and is_state(entity, "on") %}
+                {% set ns.action = ns.action+["0"] %}
+              {% elif entity is search('AO',ignorecase=True) and is_state(entity, "on") %}
+                {% set ns.action = ns.action+["1"] %}
+              {% elif entity is search('BI',ignorecase=True) and is_state(entity, "on") %}
+                {% set ns.action = ns.action+["2"] %}
+              {% elif entity is search('BO',ignorecase=True) and is_state(entity, "on") %}
+                {% set ns.action = ns.action+["3"] %}
+              {% endif %}
+            {% endfor %}
+            {% set R1, EB, R2, SA, T21, NU = 0, 0, 0, 0, 1, 0 %}
+            {% if ns.action|length>0 %}{% set EB, NU, R1 = 1, 1, ns.action[0] %}{% endif %}
+            {% if ns.action|length>1 %}{% set SA, R2 = 1, ns.action[1] %}{% endif %}
+            {"R1":{{R1}},"EB":{{EB}},"R2":{{R2}},"SA":{{SA}},"T21":{{T21}},"NU":{{NU}},"send":"clear"}
+          icon: "mdi:download"
+    0x02: *F60201
+  0x04:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: binary_sensor
+        name: "status"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.KC == 112 %}ON{% else %}OFF{% endif %}
+  0x05:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+        persistent: "false"
+      entities:
+      - component: "device_automation"
+        name: "trig_water"
+        config:
+          automation_type: "trigger"
+          type: "water_detected"
+          subtype: "sensor"
+          topic: ""
+          payload: "17"
+          value_template: "{{ value_json.WAS }}"
+    0x02:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: binary_sensor
+        name: "alarm"
+        config:
+          state_topic: ""
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.SMO == 16 %}on{% else %}off{% endif %}
+          device_class: smoke
+      - component: binary_sensor
+        name: "battery"
+        config:
+          state_topic: ""
+          payload_on: "on"
+          payload_off: "off"
+          value_template: >-
+            {% if value_json.SMO == 48 %}on{% else %}off{% endif %}
+          device_class: battery
+  0x10:
+    0x00:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: binary_sensor
+        name: "state_2p"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.WIN == 3 %}OFF{% else %}ON{% endif %}
+          device_class: "window"
+      - component: sensor
+        name: "state_3p"
+        config:
+          state_topic: ""
+          value_template: >-
+            {% if value_json.WIN == 3 %}off{% elif value_json.WIN == 1 %}tilt{% else %}on{% endif %}
 0xD5:
-   0x00:
-      0x01:
-         device_config:
-            command: ""
-            channel: ""
-            log_learn: ""
-            direction: ""
-            answer: ""
-         entities:
-            - component: binary_sensor
-              name: "contact"
-              config:
-                 state_topic: ""
-                 value_template: "{{ value_json.CO }}"
-                 payload_on: "0"
-                 payload_off: "1"
+  0x00:
+    0x01:
+      device_config:
+        command: ""
+        channel: ""
+        log_learn: ""
+        direction: ""
+        answer: ""
+      entities:
+      - component: binary_sensor
+        name: "contact"
+        config:
+          state_topic: ""
+          value_template: "{{ value_json.CO }}"
+          payload_on: "0"
+          payload_off: "1"
 
 # Mapping of Eltako devices using non-standard or universal EEPs to Home Assistant Entities
 eltako:
-   fhd60sb:
-      device_config:
-         - rorg: "0xA5"
-           func: "0x06"
-           type: "0x01"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-      entities:
-         - component: sensor
-           name: "lux"
-           config:
-              state_topic: "a5"
-              value_template: >-
-                {% if value_json._RAW_DATA_.split(":")[1]=="00" %}
-                  {{ value_json._RAW_DATA_.split(":")[0]|int(base=16) }}
-                {% else %}
-                  {{ value_json.ILL2 | round(1) }}
-                {% endif %}
-              device_class: "illuminance"
-              state_class: "measurement"
-              unit_of_measurement: "lx"
-   fsb14: &fsb14
-      device_config:
-         - rorg: "0xA5"
-           func: "0x3F"
-           type: "0x7F"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-         - rorg: "0xF6"
-           func: "0x02"
-           type: "0x01"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-      entities:
-         - component: "button"
-           name: "pairing"
-           config:
-              command_topic: "a5/req"
-              payload_press: >-
-                {"raw_data":"FF:F8:0D:80","send":"clear+learn+raw_data"}
-              icon: "mdi:connection"
-         - component: "number"
-           name: "shut_time"
-           config:
-              command_topic: "a5/__trash"
-              min: "1"
-              max: "255"
-              step: "0.1"
-              mode: "box"
-              unit_of_measurement: "s"
-              icon: "mdi:sort-clock-ascending-outline"
-         - component: "cover"
-           name: "cover"
-           config:
-              command_topic: "a5/req"
-              payload_open: >-
-                {"DB3":"0","DB2":"0","DB1":"1","DB0":"8","send":"clear"}
-              payload_close: >-
-                {"DB3":"0","DB2":"0","DB1":"2","DB0":"8","send":"clear"}
-              payload_stop: >-
-                {"DB3":"0","DB2":"0","DB1":"0","DB0":"8","send":"clear"}
-              state_topic: "+"
-              state_stopped: "0"
-              state_opening: "01"
-              state_closing: "02"
-              state_open: "70"
-              state_closed: "50"
-              value_template: >-
-                {% if value_json._RAW_DATA_.split(":")|length == 2 %}
-                  {{ value_json._RAW_DATA_.split(":")[0] }}
-                {% else %}
-                  {{ states(entity_id)|int(default=0) }}
-                {% endif %}
-              set_position_topic: "a5/req"
-              set_position_template: >-
-                {% set ns = namespace() %}
-                {% for entity in device_entities(device_id(entity_id)) %}
-                  {% if entity is search('shut_time$',ignorecase=True) %}
-                    {% set ns.shut_time_sec = states(entity)|float(default=255.0) %}
-                  {% endif %}
-                {% endfor %}
-                {% set cur_pos = state_attr(entity_id,"current_position")|int(default=0) %}
-                {% set step = position - cur_pos %}
-                {% set DB1 = iif(step < 0,2,1) %}
-                {% set drive_time_100ms = (((step|abs)*ns.shut_time_sec/100)*10)|int %}
-                {% set shut_time_msb = (drive_time_100ms/256)|int %}
-                {% set shut_time_lsb = (drive_time_100ms%256)|int %}
-                {"DB3":"{{shut_time_msb}}","DB2":"{{shut_time_lsb}}","DB1":"{{DB1}}","DB0":"10","send":"clear"}
-              position_topic: "+"
-              position_template: >-
-                {% set ns = namespace() %}
-                {% for entity in device_entities(device_id(entity_id)) %}
-                  {% if entity is search('shut_time$',ignorecase=True) %}
-                    {% set ns.shut_time_sec = states(entity)|float(default=255) %}
-                  {% endif %}
-                {% endfor %}
-                {% if value_json._RAW_DATA_.split(":")|length == 2 %}
-                  {% if value_json._RAW_DATA_.split(":")[0]=="70" %}{{position_open}}
-                  {% elif value_json._RAW_DATA_.split(":")[0]=="50" %}{{position_closed}}
-                  {% endif %}
-                {% elif value_json._RAW_DATA_.split(":")|length == 5 %}
-                  {% set drive_time_sec = (value_json.DB3*256+value_json.DB2)|int(default=0)/10 %}
-                  {% set step = drive_time_sec*100/ns.shut_time_sec %}
-                  {% set dir = iif(value_json.DB1==1,1,-1) %}
-                  {% set cur_pos = state_attr(entity_id,"current_position")|int(default=0) %}
-                  {{max(0, min((cur_pos+step*dir)|int, 100))}}
-                {% else %}
-                  {{ states(entity_id)|int(default=0) }}
-                {% endif %}
-         - component: binary_sensor
-           name: "end_top"
-           config:
-              state_topic: "f6"
-              payload_on: "on"
-              payload_off: "off"
-              value_template: >-
-                {{ iif(value_json._RAW_DATA_.split(":")[0]=="70","on","off") }}
-         - component: binary_sensor
-           name: "end_bottom"
-           config:
-              state_topic: "f6"
-              payload_on: "on"
-              payload_off: "off"
-              value_template: >-
-                {{ iif(value_json._RAW_DATA_.split(":")[0]=="50","on","off") }}
-         - component: binary_sensor
-           name: "start_up"
-           config:
-              state_topic: "f6"
-              payload_on: "on"
-              payload_off: "off"
-              value_template: >-
-                {{ iif(value_json._RAW_DATA_.split(":")[0]=="01","on","off") }}
-         - component: binary_sensor
-           name: "start_down"
-           config:
-              state_topic: "f6"
-              payload_on: "on"
-              payload_off: "off"
-              value_template: >-
-                {{ iif(value_json._RAW_DATA_.split(":")[0]=="02","on","off") }}
-   fsb61: *fsb14
-   fj62: &fj62
-      device_config:
-         - rorg: "0xA5"
-           func: "0x3F"
-           type: "0x7F"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-           persistent: "false"
-         - rorg: "0xF6"
-           func: "0x02"
-           type: "0x01"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-           persistent: "false"
-      entities:
-         - component: "button"
-           name: "pairing"
-           config:
-              command_topic: "a5/req"
-              payload_press: >-
-                {"raw_data":"FF:F8:0D:80","send":"clear+learn+raw_data"}
-              icon: "mdi:connection"
-         - component: "button"
-           name: "unlock_pairing"
-           config:
-              command_topic: "a5/req"
-              payload_press: >-
-                {"raw_data":"00:00:00:28","send":"clear+raw_data"}
-              icon: "mdi:connection"
-         - component: "number"
-           name: "shut_time"
-           config:
-              command_topic: "a5/__trash"
-              min: "1"
-              max: "255"
-              step: "0.1"
-              mode: "box"
-              unit_of_measurement: "s"
-              icon: "mdi:sort-clock-ascending-outline"
-         - component: "cover"
-           name: "cover"
-           config:
-              command_topic: "a5/req"
-              payload_open: >-
-                {"DB3":"0","DB2":"0","DB1":"1","DB0":"8","send":"clear"}
-              payload_close: >-
-                {"DB3":"0","DB2":"0","DB1":"2","DB0":"8","send":"clear"}
-              payload_stop: >-
-                {"DB3":"0","DB2":"0","DB1":"0","DB0":"8","send":"clear"}
-              state_topic: "+"
-              state_stopped: "0"
-              state_opening: "01"
-              state_closing: "02"
-              state_open: "70"
-              state_closed: "50"
-              value_template: >-
-                {% if value_json._RAW_DATA_.split(":")|length == 2 %}
-                  {{ value_json._RAW_DATA_.split(":")[0] }}
-                {% else %}
-                  {{ states(entity_id)|int(default=0) }}
-                {% endif %}
-              set_position_topic: "a5/req"
-              set_position_template: >-
-                {% set ns = namespace() %}
-                {% for entity in device_entities(device_id(entity_id)) %}
-                  {% if entity is search('shut_time$',ignorecase=True) %}
-                    {% set ns.shut_time_sec = states(entity)|float(default=255.0) %}
-                  {% endif %}
-                {% endfor %}
-                {% set cur_pos = state_attr(entity_id,"current_position")|int(default=0) %}
-                {% set step = position - cur_pos %}
-                {% set DB1 = iif(step < 0,2,1) %}
-                {% set drive_time_100ms = (((step|abs)*ns.shut_time_sec/100)*10)|int %}
-                {% set shut_time_msb = (drive_time_100ms/256)|int %}
-                {% set shut_time_lsb = (drive_time_100ms%256)|int %}
-                {"DB3":"{{shut_time_msb}}","DB2":"{{shut_time_lsb}}","DB1":"{{DB1}}","DB0":"10","send":"clear"}
-              position_topic: "+"
-              position_template: >-
-                {% set ns = namespace() %}
-                {% for entity in device_entities(device_id(entity_id)) %}
-                  {% if entity is search('shut_time$',ignorecase=True) %}
-                    {% set ns.shut_time_sec = states(entity)|float(default=255) %}
-                  {% endif %}
-                {% endfor %}
-                {% if value_json._RAW_DATA_.split(":")|length == 2 %}
-                  {% if value_json._RAW_DATA_.split(":")[0]=="70" %}{{position_open}}
-                  {% elif value_json._RAW_DATA_.split(":")[0]=="50" %}{{position_closed}}
-                  {% else %}{{ state_attr(entity_id, "current_position") | int(default=0) }}
-                  {% endif %}
-                {% elif value_json._RAW_DATA_.split(":")|length == 5 %}
-                  {% set drive_time_sec = (value_json.DB3*256+value_json.DB2)|int(default=0)/10 %}
-                  {% set step = drive_time_sec*100/ns.shut_time_sec %}
-                  {% set dir = iif(value_json.DB1==1,1,-1) %}
-                  {% set cur_pos = state_attr(entity_id,"current_position")|int(default=0) %}
-                  {{max(0, min((cur_pos+step*dir)|int, 100))}}
-                {% else %}
-                  {{ states(entity_id)|int(default=0) }}
-                {% endif %}
-         - component: binary_sensor
-           name: "end_top"
-           config:
-              state_topic: "f6"
-              payload_on: "on"
-              payload_off: "off"
-              value_template: >-
-                {{ iif(value_json._RAW_DATA_.split(":")[0]=="70","on","off") }}
-         - component: binary_sensor
-           name: "end_bottom"
-           config:
-              state_topic: "f6"
-              payload_on: "on"
-              payload_off: "off"
-              value_template: >-
-                {{ iif(value_json._RAW_DATA_.split(":")[0]=="50","on","off") }}
-         - component: binary_sensor
-           name: "start_up"
-           config:
-              state_topic: "f6"
-              payload_on: "on"
-              payload_off: "off"
-              value_template: >-
-                {{ iif(value_json._RAW_DATA_.split(":")[0]=="01","on","off") }}
-         - component: binary_sensor
-           name: "start_down"
-           config:
-              state_topic: "f6"
-              payload_on: "on"
-              payload_off: "off"
-              value_template: >-
-                {{ iif(value_json._RAW_DATA_.split(":")[0]=="02","on","off") }}
-   tf61j: *fj62
-   fsr14: &fsr14
-      device_config:
-         - rorg: "0xA5"
-           func: "0x38"
-           type: "0x08"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-         - rorg: "0xF6"
-           func: "0x02"
-           type: "0x01"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-      entities:
-         - component: "button"
-           name: "pairing"
-           config:
-              command_topic: "a5/req"
-              payload_press: >-
-                {"raw_data":"E0:40:0D:80","send":"clear+learn+raw_data"}
-              icon: "mdi:connection"
-         - component: "switch"
-           name: "switch"
-           config:
-              command_topic: "a5/req"
-              payload_on: >-
-                {"raw_data":"01:00:00:09","send":"clear+raw_data"}
-              payload_off: >-
-                {"raw_data":"01:00:00:08","send":"clear+raw_data"}
-              state_topic: "f6"
-              value_template: >-
-                {% if value_json._RAW_DATA_.split(":")[0]=="70" %}ON{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}OFF{% endif %}
-              enabled_by_default: "false"
-              device_class: "outlet"
-         - component: "light"
-           name: "light"
-           config:
-              schema: "template"
-              command_topic: "a5/req"
-              command_on_template: >-
-                {"raw_data":"01:00:00:09","send":"clear+raw_data"}
-              command_off_template: >-
-                {"raw_data":"01:00:00:08","send":"clear+raw_data"}
-              state_topic: "f6"
-              state_template: >-
-                {% if value_json._RAW_DATA_.split(":")[0]=="70" %}on{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}off{% endif %}
-   fsr61: *fsr14
-   tf61l: &tf61l
-      device_config:
-         - rorg: "0xA5"
-           func: "0x38"
-           type: "0x08"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-         - rorg: "0xF6"
-           func: "0x02"
-           type: "0x01"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-      entities:
-         - component: "button"
-           name: "pairing"
-           config:
-              command_topic: "a5/req"
-              payload_press: >-
-                {"raw_data":"E0:40:0D:80","send":"clear+learn+raw_data"}
-              icon: "mdi:connection"
-         - component: "button"
-           name: "unlock_pairing"
-           config:
-              command_topic: "a5/req"
-              payload_press: >-
-                {"raw_data":"00:00:00:28","send":"clear+raw_data"}
-              icon: "mdi:connection"
-         - component: "button"
-           name: "enable_feedback"
-           config:
-              command_topic: "a5/req"
-              payload_press: >-
-                {"raw_data":"00:00:00:08","send":"clear+raw_data"}
-              icon: "mdi:connection"
-         - component: "switch"
-           name: "switch"
-           config:
-              command_topic: "a5/req"
-              payload_on: >-
-                {"raw_data":"01:00:00:09","send":"clear+raw_data"}
-              payload_off: >-
-                {"raw_data":"01:00:00:08","send":"clear+raw_data"}
-              state_topic: "f6"
-              value_template: >-
-                {% if value_json._RAW_DATA_.split(":")[0]=="70" %}ON{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}OFF{% endif %}
-              enabled_by_default: "false"
-              device_class: "outlet"
-         - component: "light"
-           name: "light"
-           config:
-              schema: "template"
-              command_topic: "a5/req"
-              command_on_template: >-
-                {"raw_data":"01:00:00:09","send":"clear+raw_data"}
-              command_off_template: >-
-                {"raw_data":"01:00:00:08","send":"clear+raw_data"}
-              state_topic: "f6"
-              state_template: >-
-                {% if value_json._RAW_DATA_.split(":")[0]=="70" %}on{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}off{% endif %}
-   fr62: *tf61l
-   fud14: &fud14
-      device_config:
-         - rorg: "0xA5"
-           func: "0x38"
-           type: "0x08"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-         - rorg: "0xF6"
-           func: "0x02"
-           type: "0x01"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-      entities:
-         - component: "button"
-           name: "pairing"
-           config:
-              command_topic: "a5/req"
-              payload_press: >-
-                {"raw_data":"E0:40:0D:80","send":"clear+learn+raw_data"}
-              icon: "mdi:connection"
-         - component: "number"
-           name: "speed"
-           config:
-              command_topic: "a5/__trash"
-              min: "0"
-              max: "255"
-              step: "1"
-              mode: "slider"
-              icon: "mdi:speedometer"
-         - component: "light"
-           name: "light"
-           config:
-              schema: "template"
-              command_topic: "a5/req"
-              command_on_template: >-
-                {% set ns = namespace() %}
-                {% for entity in device_entities(device_id(entity_id)) %}
-                  {% if entity is search('speed$',ignorecase=True) %}
-                    {% set ns.dim_speed = '%02x' % (states(entity)|int(default=0)) %}
-                  {% endif %}
-                {% endfor %}
-                {% if transition is defined %}
-                  {% set ns.dim_speed = '%02x' % (transition|int(default=0)) %}
-                {% endif %}
-                {% set ns.dim_val = "FF" %}
-                {% if brightness is defined %}
-                  {% set ns.dim_val = '%02x' % (((brightness|int(default=255))*100/255)|int) %}
-                {% endif %}
-                {"raw_data":"02:{{ns.dim_val}}:{{ns.dim_speed}}:09","send":"clear+raw_data"}
-              command_off_template: >-
-                {% set ns = namespace() %}
-                {% for entity in device_entities(device_id(entity_id)) %}
-                  {% if entity is search('speed$',ignorecase=True) %}
-                    {% set ns.dim_speed = '%02x' % (states(entity)|int(default=0)) %}
-                  {% endif %}
-                {% endfor %}
-                {% if transition is defined %}
-                  {% set ns.dim_speed = '%02x' % (transition|int(default=0)) %}
-                {% endif %}
-                {"raw_data":"02:00:{{ns.dim_speed}}:08","send":"clear+raw_data"}
-              state_topic: "+"
-              state_template: >-
-                {% if value_json._RAW_DATA_.split(":")|length == 2 %}
-                  {% if value_json._RAW_DATA_.split(":")[0]=="70" %}on{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}off{% endif %}
-                {% elif value_json._RAW_DATA_.split(":")|length == 5 %}
-                  {% if value_json._RAW_DATA_.split(":")[3]=="09" %}on{% elif value_json._RAW_DATA_.split(":")[3]=="08" %}off{% endif %}
-                {% endif %}
-              brightness_template: >-
-                {% if value_json._RAW_DATA_.split(":")|length == 5 %}
-                  {{ (value_json._RAW_DATA_.split(":")[1]|int(default=0,base=16)*255/100)|int }}
-                {% else %}
-                  {{ states(entity_id)|int(default=0) }}
-                {% endif %}
-   fud61: *fud14
-   fdg14: *fud14
-   fld61: *fud14
-   tf61d:
-      device_config:
-         - rorg: "0xA5"
-           func: "0x38"
-           type: "0x08"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-         - rorg: "0xF6"
-           func: "0x02"
-           type: "0x01"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-      entities:
-         - component: "button"
-           name: "pairing"
-           config:
-              command_topic: "a5/req"
-              payload_press: >-
-                {"raw_data":"E0:40:0D:80","send":"clear+learn+raw_data"}
-              icon: "mdi:connection"
-         - component: "number"
-           name: "speed"
-           config:
-              command_topic: "a5/__trash"
-              min: "0"
-              max: "255"
-              step: "1"
-              mode: "slider"
-              icon: "mdi:speedometer"
-         - component: "light"
-           name: "light"
-           config:
-              schema: "template"
-              command_topic: "a5/req"
-              command_on_template: >-
-                {% set ns = namespace() %}
-                {% for entity in device_entities(device_id(entity_id)) %}
-                  {% if entity is search('speed$',ignorecase=True) %}
-                    {% set ns.dim_speed = '%02x' % (states(entity)|int(default=0)) %}
-                  {% endif %}
-                {% endfor %}
-                {% if transition is defined %}
-                  {% set ns.dim_speed = '%02x' % (transition|int(default=0)) %}
-                {% endif %}
-                {% set ns.dim_val = "FF" %}
-                {% if brightness is defined %}
-                  {% set ns.dim_val = '%02x' % (((brightness|int(default=255))*100/255)|int) %}
-                {% endif %}
-                {"raw_data":"02:{{ns.dim_val}}:{{ns.dim_speed}}:09","send":"clear+raw_data"}
-              command_off_template: >-
-                {% set ns = namespace() %}
-                {% for entity in device_entities(device_id(entity_id)) %}
-                  {% if entity is search('speed$',ignorecase=True) %}
-                    {% set ns.dim_speed = '%02x' % (states(entity)|int(default=0)) %}
-                  {% endif %}
-                {% endfor %}
-                {% if transition is defined %}
-                  {% set ns.dim_speed = '%02x' % (transition|int(default=0)) %}
-                {% endif %}
-                {"raw_data":"02:00:{{ns.dim_speed}}:08","send":"clear+raw_data"}
-              state_topic: "f6"
-              state_template: >-
-                {% if value_json._RAW_DATA_.split(":")[0]=="70" %}on{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}off{% endif %}
-              brightness_template: >-
-                {% if value_json._RAW_DATA_.split(":")|length == 5 %}
-                  {{ (value_json._RAW_DATA_.split(":")[1]|int(default=0,base=16)*255/100)|int }}
-                {% else %}
-                  {{ states(entity_id)|int(default=0) }}
-                {% endif %}
-   fttb:
-      device_config:
-         - rorg: "0xA5"
-           func: "0x07"
-           type: "0x01"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-         - rorg: "0xF6"
-           func: "0x01"
-           type: "0x01"
-           command: ""
-           channel: ""
-           log_learn: ""
-           direction: ""
-           answer: ""
-      entities:
-         - component: "binary_sensor"
-           name: "Presence"
-           config:
-              state_topic: "a5"
-              value_template: >-
-                {% if value_json.PIRS >= 128 %}
-                  ON
-                {% else %}
-                  OFF
-                {% endif %}
-              device_class: "presence"
-              off_delay: 60
-         - component: "sensor"
-           name: "v_raw"
-           config:
-              state_topic: "a5"
-              value_template: >- 
-                {{ value_json.SVC }}
-              enabled_by_default: "false"
-              availability_topic: "a5"
-              availability_template: >-
-                {% if value_json.SVA == 1 %}
-                  online
-                {% else %}
-                  offline
-                {% endif %}
-              device_class: "voltage"
-              state_class: "measurement"
-              unit_of_measurement: "V"
-         - component: "sensor"
-           name: "voltage"
-           config:
-              state_topic: "a5"
-              value_template: >- 
-                {{ value_json.SVC | round(2) }}
-              availability_topic: "a5"
-              availability_template: >-
-                {% if value_json.SVA == 1 %}
-                  online
-                {% else %}
-                  offline
-                {% endif %}
-              device_class: "voltage"
-              state_class: "measurement"
-              unit_of_measurement: "V"
-         - component: "binary_sensor"
-           name: "Button"
-           config:
-              state_topic: "f6"
-              value_template: "{{ value_json.PB }}"
-              payload_on: "1"
-              payload_off: "0"
-   tf100l: *fsr14
-   fbh55esb:
-      device_config:
-        - rorg: "0xA5"
-          func: "0x08"
-          type: "0x01"
-          command: ""
-          channel: ""
-          log_learn: ""
-          direction: ""
-          answer: ""
-      entities:
-            - component: "sensor"
-              name: "voltage"
-              config:
-                 state_topic: "a5"
-                 value_template: "{{ value_json.SVC | round(2) }}"
-                 device_class: "voltage"
-                 state_class: "measurement"
-                 unit_of_measurement: "V"
-            - component: "sensor"
-              name: "lux"
-              config:
-                 state_topic: "a5"
-                 value_template: "{{ value_json.ILL | round(1) }}"
-                 device_class: "illuminance"
-                 state_class: "measurement"
-                 unit_of_measurement: "lx"
-            - component: binary_sensor
-              name: "pir"
-              config:
-                 state_topic: "a5"
-                 value_template: >-
-                   {% if value_json.PIRS == 0 %}ON{% else %}OFF{% endif %}
-                 device_class: "occupancy"
+  fhd60sb:
+    device_config:
+    - rorg: "0xA5"
+      func: "0x06"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+    - component: sensor
+      name: "lux"
+      config:
+        state_topic: "a5"
+        value_template: >-
+          {% if value_json._RAW_DATA_.split(":")[1]=="00" %}
+            {{ value_json._RAW_DATA_.split(":")[0]|int(base=16) }}
+          {% else %}
+            {{ value_json.ILL2 | round(1) }}
+          {% endif %}
+        device_class: "illuminance"
+        state_class: "measurement"
+        unit_of_measurement: "lx"
+  fsb14: &fsb14
+    device_config:
+    - rorg: "0xA5"
+      func: "0x3F"
+      type: "0x7F"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    - rorg: "0xF6"
+      func: "0x02"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+    - component: "button"
+      name: "pairing"
+      config:
+        command_topic: "a5/req"
+        payload_press: >-
+          {"raw_data":"FF:F8:0D:80","send":"clear+learn+raw_data"}
+        icon: "mdi:connection"
+    - component: "number"
+      name: "shut_time"
+      config:
+        command_topic: "a5/__trash"
+        min: "1"
+        max: "255"
+        step: "0.1"
+        mode: "box"
+        unit_of_measurement: "s"
+        icon: "mdi:sort-clock-ascending-outline"
+    - component: "cover"
+      name: "cover"
+      config:
+        command_topic: "a5/req"
+        payload_open: >-
+          {"DB3":"0","DB2":"0","DB1":"1","DB0":"8","send":"clear"}
+        payload_close: >-
+          {"DB3":"0","DB2":"0","DB1":"2","DB0":"8","send":"clear"}
+        payload_stop: >-
+          {"DB3":"0","DB2":"0","DB1":"0","DB0":"8","send":"clear"}
+        state_topic: "+"
+        state_stopped: "0"
+        state_opening: "01"
+        state_closing: "02"
+        state_open: "70"
+        state_closed: "50"
+        value_template: >-
+          {% if value_json._RAW_DATA_.split(":")|length == 2 %}
+            {{ value_json._RAW_DATA_.split(":")[0] }}
+          {% else %}
+            {{ states(entity_id)|int(default=0) }}
+          {% endif %}
+        set_position_topic: "a5/req"
+        set_position_template: >-
+          {% set ns = namespace() %}
+          {% for entity in device_entities(device_id(entity_id)) %}
+            {% if entity is search('shut_time$',ignorecase=True) %}
+              {% set ns.shut_time_sec = states(entity)|float(default=255.0) %}
+            {% endif %}
+          {% endfor %}
+          {% set cur_pos = state_attr(entity_id,"current_position")|int(default=0) %}
+          {% set step = position - cur_pos %}
+          {% set DB1 = iif(step < 0,2,1) %}
+          {% set drive_time_100ms = (((step|abs)*ns.shut_time_sec/100)*10)|int %}
+          {% set shut_time_msb = (drive_time_100ms/256)|int %}
+          {% set shut_time_lsb = (drive_time_100ms%256)|int %}
+          {"DB3":"{{shut_time_msb}}","DB2":"{{shut_time_lsb}}","DB1":"{{DB1}}","DB0":"10","send":"clear"}
+        position_topic: "+"
+        position_template: >-
+          {% set ns = namespace() %}
+          {% for entity in device_entities(device_id(entity_id)) %}
+            {% if entity is search('shut_time$',ignorecase=True) %}
+              {% set ns.shut_time_sec = states(entity)|float(default=255) %}
+            {% endif %}
+          {% endfor %}
+          {% if value_json._RAW_DATA_.split(":")|length == 2 %}
+            {% if value_json._RAW_DATA_.split(":")[0]=="70" %}{{position_open}}
+            {% elif value_json._RAW_DATA_.split(":")[0]=="50" %}{{position_closed}}
+            {% endif %}
+          {% elif value_json._RAW_DATA_.split(":")|length == 5 %}
+            {% set drive_time_sec = (value_json.DB3*256+value_json.DB2)|int(default=0)/10 %}
+            {% set step = drive_time_sec*100/ns.shut_time_sec %}
+            {% set dir = iif(value_json.DB1==1,1,-1) %}
+            {% set cur_pos = state_attr(entity_id,"current_position")|int(default=0) %}
+            {{max(0, min((cur_pos+step*dir)|int, 100))}}
+          {% else %}
+            {{ states(entity_id)|int(default=0) }}
+          {% endif %}
+    - component: binary_sensor
+      name: "end_top"
+      config:
+        state_topic: "f6"
+        payload_on: "on"
+        payload_off: "off"
+        value_template: >-
+          {{ iif(value_json._RAW_DATA_.split(":")[0]=="70","on","off") }}
+    - component: binary_sensor
+      name: "end_bottom"
+      config:
+        state_topic: "f6"
+        payload_on: "on"
+        payload_off: "off"
+        value_template: >-
+          {{ iif(value_json._RAW_DATA_.split(":")[0]=="50","on","off") }}
+    - component: binary_sensor
+      name: "start_up"
+      config:
+        state_topic: "f6"
+        payload_on: "on"
+        payload_off: "off"
+        value_template: >-
+          {{ iif(value_json._RAW_DATA_.split(":")[0]=="01","on","off") }}
+    - component: binary_sensor
+      name: "start_down"
+      config:
+        state_topic: "f6"
+        payload_on: "on"
+        payload_off: "off"
+        value_template: >-
+          {{ iif(value_json._RAW_DATA_.split(":")[0]=="02","on","off") }}
+  fsb61: *fsb14
+  fj62: &fj62
+    device_config:
+    - rorg: "0xA5"
+      func: "0x3F"
+      type: "0x7F"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+      persistent: "false"
+    - rorg: "0xF6"
+      func: "0x02"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+      persistent: "false"
+    entities:
+    - component: "button"
+      name: "pairing"
+      config:
+        command_topic: "a5/req"
+        payload_press: >-
+          {"raw_data":"FF:F8:0D:80","send":"clear+learn+raw_data"}
+        icon: "mdi:connection"
+    - component: "button"
+      name: "unlock_pairing"
+      config:
+        command_topic: "a5/req"
+        payload_press: >-
+          {"raw_data":"00:00:00:28","send":"clear+raw_data"}
+        icon: "mdi:connection"
+    - component: "number"
+      name: "shut_time"
+      config:
+        command_topic: "a5/__trash"
+        min: "1"
+        max: "255"
+        step: "0.1"
+        mode: "box"
+        unit_of_measurement: "s"
+        icon: "mdi:sort-clock-ascending-outline"
+    - component: "cover"
+      name: "cover"
+      config:
+        command_topic: "a5/req"
+        payload_open: >-
+          {"DB3":"0","DB2":"0","DB1":"1","DB0":"8","send":"clear"}
+        payload_close: >-
+          {"DB3":"0","DB2":"0","DB1":"2","DB0":"8","send":"clear"}
+        payload_stop: >-
+          {"DB3":"0","DB2":"0","DB1":"0","DB0":"8","send":"clear"}
+        state_topic: "+"
+        state_stopped: "0"
+        state_opening: "01"
+        state_closing: "02"
+        state_open: "70"
+        state_closed: "50"
+        value_template: >-
+          {% if value_json._RAW_DATA_.split(":")|length == 2 %}
+            {{ value_json._RAW_DATA_.split(":")[0] }}
+          {% else %}
+            {{ states(entity_id)|int(default=0) }}
+          {% endif %}
+        set_position_topic: "a5/req"
+        set_position_template: >-
+          {% set ns = namespace() %}
+          {% for entity in device_entities(device_id(entity_id)) %}
+            {% if entity is search('shut_time$',ignorecase=True) %}
+              {% set ns.shut_time_sec = states(entity)|float(default=255.0) %}
+            {% endif %}
+          {% endfor %}
+          {% set cur_pos = state_attr(entity_id,"current_position")|int(default=0) %}
+          {% set step = position - cur_pos %}
+          {% set DB1 = iif(step < 0,2,1) %}
+          {% set drive_time_100ms = (((step|abs)*ns.shut_time_sec/100)*10)|int %}
+          {% set shut_time_msb = (drive_time_100ms/256)|int %}
+          {% set shut_time_lsb = (drive_time_100ms%256)|int %}
+          {"DB3":"{{shut_time_msb}}","DB2":"{{shut_time_lsb}}","DB1":"{{DB1}}","DB0":"10","send":"clear"}
+        position_topic: "+"
+        position_template: >-
+          {% set ns = namespace() %}
+          {% for entity in device_entities(device_id(entity_id)) %}
+            {% if entity is search('shut_time$',ignorecase=True) %}
+              {% set ns.shut_time_sec = states(entity)|float(default=255) %}
+            {% endif %}
+          {% endfor %}
+          {% if value_json._RAW_DATA_.split(":")|length == 2 %}
+            {% if value_json._RAW_DATA_.split(":")[0]=="70" %}{{position_open}}
+            {% elif value_json._RAW_DATA_.split(":")[0]=="50" %}{{position_closed}}
+            {% else %}{{ state_attr(entity_id, "current_position") | int(default=0) }}
+            {% endif %}
+          {% elif value_json._RAW_DATA_.split(":")|length == 5 %}
+            {% set drive_time_sec = (value_json.DB3*256+value_json.DB2)|int(default=0)/10 %}
+            {% set step = drive_time_sec*100/ns.shut_time_sec %}
+            {% set dir = iif(value_json.DB1==1,1,-1) %}
+            {% set cur_pos = state_attr(entity_id,"current_position")|int(default=0) %}
+            {{max(0, min((cur_pos+step*dir)|int, 100))}}
+          {% else %}
+            {{ states(entity_id)|int(default=0) }}
+          {% endif %}
+    - component: binary_sensor
+      name: "end_top"
+      config:
+        state_topic: "f6"
+        payload_on: "on"
+        payload_off: "off"
+        value_template: >-
+          {{ iif(value_json._RAW_DATA_.split(":")[0]=="70","on","off") }}
+    - component: binary_sensor
+      name: "end_bottom"
+      config:
+        state_topic: "f6"
+        payload_on: "on"
+        payload_off: "off"
+        value_template: >-
+          {{ iif(value_json._RAW_DATA_.split(":")[0]=="50","on","off") }}
+    - component: binary_sensor
+      name: "start_up"
+      config:
+        state_topic: "f6"
+        payload_on: "on"
+        payload_off: "off"
+        value_template: >-
+          {{ iif(value_json._RAW_DATA_.split(":")[0]=="01","on","off") }}
+    - component: binary_sensor
+      name: "start_down"
+      config:
+        state_topic: "f6"
+        payload_on: "on"
+        payload_off: "off"
+        value_template: >-
+          {{ iif(value_json._RAW_DATA_.split(":")[0]=="02","on","off") }}
+  tf61j: *fj62
+  fsr14: &fsr14
+    device_config:
+    - rorg: "0xA5"
+      func: "0x38"
+      type: "0x08"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    - rorg: "0xF6"
+      func: "0x02"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+    - component: "button"
+      name: "pairing"
+      config:
+        command_topic: "a5/req"
+        payload_press: >-
+          {"raw_data":"E0:40:0D:80","send":"clear+learn+raw_data"}
+        icon: "mdi:connection"
+    - component: "switch"
+      name: "switch"
+      config:
+        command_topic: "a5/req"
+        payload_on: >-
+          {"raw_data":"01:00:00:09","send":"clear+raw_data"}
+        payload_off: >-
+          {"raw_data":"01:00:00:08","send":"clear+raw_data"}
+        state_topic: "f6"
+        value_template: >-
+          {% if value_json._RAW_DATA_.split(":")[0]=="70" %}ON{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}OFF{% endif %}
+        enabled_by_default: "false"
+        device_class: "outlet"
+    - component: "light"
+      name: "light"
+      config:
+        schema: "template"
+        command_topic: "a5/req"
+        command_on_template: >-
+          {"raw_data":"01:00:00:09","send":"clear+raw_data"}
+        command_off_template: >-
+          {"raw_data":"01:00:00:08","send":"clear+raw_data"}
+        state_topic: "f6"
+        state_template: >-
+          {% if value_json._RAW_DATA_.split(":")[0]=="70" %}on{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}off{% endif %}
+  fsr61: *fsr14
+  tf61l: &tf61l
+    device_config:
+    - rorg: "0xA5"
+      func: "0x38"
+      type: "0x08"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    - rorg: "0xF6"
+      func: "0x02"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+    - component: "button"
+      name: "pairing"
+      config:
+        command_topic: "a5/req"
+        payload_press: >-
+          {"raw_data":"E0:40:0D:80","send":"clear+learn+raw_data"}
+        icon: "mdi:connection"
+    - component: "button"
+      name: "unlock_pairing"
+      config:
+        command_topic: "a5/req"
+        payload_press: >-
+          {"raw_data":"00:00:00:28","send":"clear+raw_data"}
+        icon: "mdi:connection"
+    - component: "button"
+      name: "enable_feedback"
+      config:
+        command_topic: "a5/req"
+        payload_press: >-
+          {"raw_data":"00:00:00:08","send":"clear+raw_data"}
+        icon: "mdi:connection"
+    - component: "switch"
+      name: "switch"
+      config:
+        command_topic: "a5/req"
+        payload_on: >-
+          {"raw_data":"01:00:00:09","send":"clear+raw_data"}
+        payload_off: >-
+          {"raw_data":"01:00:00:08","send":"clear+raw_data"}
+        state_topic: "f6"
+        value_template: >-
+          {% if value_json._RAW_DATA_.split(":")[0]=="70" %}ON{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}OFF{% endif %}
+        enabled_by_default: "false"
+        device_class: "outlet"
+    - component: "light"
+      name: "light"
+      config:
+        schema: "template"
+        command_topic: "a5/req"
+        command_on_template: >-
+          {"raw_data":"01:00:00:09","send":"clear+raw_data"}
+        command_off_template: >-
+          {"raw_data":"01:00:00:08","send":"clear+raw_data"}
+        state_topic: "f6"
+        state_template: >-
+          {% if value_json._RAW_DATA_.split(":")[0]=="70" %}on{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}off{% endif %}
+  fr62: *tf61l
+  fud14: &fud14
+    device_config:
+    - rorg: "0xA5"
+      func: "0x38"
+      type: "0x08"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    - rorg: "0xF6"
+      func: "0x02"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+    - component: "button"
+      name: "pairing"
+      config:
+        command_topic: "a5/req"
+        payload_press: >-
+          {"raw_data":"E0:40:0D:80","send":"clear+learn+raw_data"}
+        icon: "mdi:connection"
+    - component: "number"
+      name: "speed"
+      config:
+        command_topic: "a5/__trash"
+        min: "0"
+        max: "255"
+        step: "1"
+        mode: "slider"
+        icon: "mdi:speedometer"
+    - component: "light"
+      name: "light"
+      config:
+        schema: "template"
+        command_topic: "a5/req"
+        command_on_template: >-
+          {% set ns = namespace() %}
+          {% for entity in device_entities(device_id(entity_id)) %}
+            {% if entity is search('speed$',ignorecase=True) %}
+              {% set ns.dim_speed = '%02x' % (states(entity)|int(default=0)) %}
+            {% endif %}
+          {% endfor %}
+          {% if transition is defined %}
+            {% set ns.dim_speed = '%02x' % (transition|int(default=0)) %}
+          {% endif %}
+          {% set ns.dim_val = "FF" %}
+          {% if brightness is defined %}
+            {% set ns.dim_val = '%02x' % (((brightness|int(default=255))*100/255)|int) %}
+          {% endif %}
+          {"raw_data":"02:{{ns.dim_val}}:{{ns.dim_speed}}:09","send":"clear+raw_data"}
+        command_off_template: >-
+          {% set ns = namespace() %}
+          {% for entity in device_entities(device_id(entity_id)) %}
+            {% if entity is search('speed$',ignorecase=True) %}
+              {% set ns.dim_speed = '%02x' % (states(entity)|int(default=0)) %}
+            {% endif %}
+          {% endfor %}
+          {% if transition is defined %}
+            {% set ns.dim_speed = '%02x' % (transition|int(default=0)) %}
+          {% endif %}
+          {"raw_data":"02:00:{{ns.dim_speed}}:08","send":"clear+raw_data"}
+        state_topic: "+"
+        state_template: >-
+          {% if value_json._RAW_DATA_.split(":")|length == 2 %}
+            {% if value_json._RAW_DATA_.split(":")[0]=="70" %}on{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}off{% endif %}
+          {% elif value_json._RAW_DATA_.split(":")|length == 5 %}
+            {% if value_json._RAW_DATA_.split(":")[3]=="09" %}on{% elif value_json._RAW_DATA_.split(":")[3]=="08" %}off{% endif %}
+          {% endif %}
+        brightness_template: >-
+          {% if value_json._RAW_DATA_.split(":")|length == 5 %}
+            {{ (value_json._RAW_DATA_.split(":")[1]|int(default=0,base=16)*255/100)|int }}
+          {% else %}
+            {{ states(entity_id)|int(default=0) }}
+          {% endif %}
+  fud61: *fud14
+  fdg14: *fud14
+  fld61: *fud14
+  tf61d:
+    device_config:
+    - rorg: "0xA5"
+      func: "0x38"
+      type: "0x08"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    - rorg: "0xF6"
+      func: "0x02"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+    - component: "button"
+      name: "pairing"
+      config:
+        command_topic: "a5/req"
+        payload_press: >-
+          {"raw_data":"E0:40:0D:80","send":"clear+learn+raw_data"}
+        icon: "mdi:connection"
+    - component: "number"
+      name: "speed"
+      config:
+        command_topic: "a5/__trash"
+        min: "0"
+        max: "255"
+        step: "1"
+        mode: "slider"
+        icon: "mdi:speedometer"
+    - component: "light"
+      name: "light"
+      config:
+        schema: "template"
+        command_topic: "a5/req"
+        command_on_template: >-
+          {% set ns = namespace() %}
+          {% for entity in device_entities(device_id(entity_id)) %}
+            {% if entity is search('speed$',ignorecase=True) %}
+              {% set ns.dim_speed = '%02x' % (states(entity)|int(default=0)) %}
+            {% endif %}
+          {% endfor %}
+          {% if transition is defined %}
+            {% set ns.dim_speed = '%02x' % (transition|int(default=0)) %}
+          {% endif %}
+          {% set ns.dim_val = "FF" %}
+          {% if brightness is defined %}
+            {% set ns.dim_val = '%02x' % (((brightness|int(default=255))*100/255)|int) %}
+          {% endif %}
+          {"raw_data":"02:{{ns.dim_val}}:{{ns.dim_speed}}:09","send":"clear+raw_data"}
+        command_off_template: >-
+          {% set ns = namespace() %}
+          {% for entity in device_entities(device_id(entity_id)) %}
+            {% if entity is search('speed$',ignorecase=True) %}
+              {% set ns.dim_speed = '%02x' % (states(entity)|int(default=0)) %}
+            {% endif %}
+          {% endfor %}
+          {% if transition is defined %}
+            {% set ns.dim_speed = '%02x' % (transition|int(default=0)) %}
+          {% endif %}
+          {"raw_data":"02:00:{{ns.dim_speed}}:08","send":"clear+raw_data"}
+        state_topic: "f6"
+        state_template: >-
+          {% if value_json._RAW_DATA_.split(":")[0]=="70" %}on{% elif value_json._RAW_DATA_.split(":")[0]=="50" %}off{% endif %}
+        brightness_template: >-
+          {% if value_json._RAW_DATA_.split(":")|length == 5 %}
+            {{ (value_json._RAW_DATA_.split(":")[1]|int(default=0,base=16)*255/100)|int }}
+          {% else %}
+            {{ states(entity_id)|int(default=0) }}
+          {% endif %}
+  fttb:
+    device_config:
+    - rorg: "0xA5"
+      func: "0x07"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    - rorg: "0xF6"
+      func: "0x01"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+    - component: "binary_sensor"
+      name: "Presence"
+      config:
+        state_topic: "a5"
+        value_template: >-
+          {% if value_json.PIRS >= 128 %}
+            ON
+          {% else %}
+            OFF
+          {% endif %}
+        device_class: "presence"
+        off_delay: 60
+    - component: "sensor"
+      name: "v_raw"
+      config:
+        state_topic: "a5"
+        value_template: >-
+          {{ value_json.SVC }}
+        enabled_by_default: "false"
+        availability_topic: "a5"
+        availability_template: >-
+          {% if value_json.SVA == 1 %}
+            online
+          {% else %}
+            offline
+          {% endif %}
+        device_class: "voltage"
+        state_class: "measurement"
+        unit_of_measurement: "V"
+    - component: "sensor"
+      name: "voltage"
+      config:
+        state_topic: "a5"
+        value_template: >-
+          {{ value_json.SVC | round(2) }}
+        availability_topic: "a5"
+        availability_template: >-
+          {% if value_json.SVA == 1 %}
+            online
+          {% else %}
+            offline
+          {% endif %}
+        device_class: "voltage"
+        state_class: "measurement"
+        unit_of_measurement: "V"
+    - component: "binary_sensor"
+      name: "Button"
+      config:
+        state_topic: "f6"
+        value_template: "{{ value_json.PB }}"
+        payload_on: "1"
+        payload_off: "0"
+  tf100l: *fsr14
+  fbh55esb:
+    device_config:
+    - rorg: "0xA5"
+      func: "0x08"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+    - component: "sensor"
+      name: "voltage"
+      config:
+        state_topic: "a5"
+        value_template: "{{ value_json.SVC | round(2) }}"
+        device_class: "voltage"
+        state_class: "measurement"
+        unit_of_measurement: "V"
+    - component: "sensor"
+      name: "lux"
+      config:
+        state_topic: "a5"
+        value_template: "{{ value_json.ILL | round(1) }}"
+        device_class: "illuminance"
+        state_class: "measurement"
+        unit_of_measurement: "lx"
+    - component: binary_sensor
+      name: "pir"
+      config:
+        state_topic: "a5"
+        value_template: >-
+          {% if value_json.PIRS == 0 %}ON{% else %}OFF{% endif %}
+        device_class: "occupancy"
 
 # Mapping for Afriso devices
 afriso:
    # https://www.afriso.com/en/PM/Domestic-technology/Equipment-for-surface-heating-and-cooling-systems/Room-temperature-sensor-FT-FTF-wireless
-   ft:
-      device_config:
-        - rorg: "0xA5"
-          func: "0x10"
-          type: "0x03"
-          command: ""
-          channel: ""
-          log_learn: ""
-          direction: ""
-          answer: ""
-      entities:
-         - component: sensor
-           name: "setpoint"
-           config:
-              state_topic: "a5"
-              value_template: >-
-                {{ ((value_json.SP | float(default=0)) / 255.0 * 22.0 + 8.0) | round(1) }}
-              device_class: "temperature"
-              state_class: "measurement"
-              unit_of_measurement: "°C"
-         - component: sensor
-           name: "temp"
-           config:
-              state_topic: "a5"
-              value_template: >-
-                {{ value_json.TMP | float(default=0) | round(1) }}
-              device_class: "temperature"
-              state_class: "measurement"
-              unit_of_measurement: "°C"
+  ft:
+    device_config:
+    - rorg: "0xA5"
+      func: "0x10"
+      type: "0x03"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+    - component: sensor
+      name: "setpoint"
+      config:
+        state_topic: "a5"
+        value_template: >-
+          {{ ((value_json.SP | float(default=0)) / 255.0 * 22.0 + 8.0) | round(1) }}
+        device_class: "temperature"
+        state_class: "measurement"
+        unit_of_measurement: "°C"
+    - component: sensor
+      name: "temp"
+      config:
+        state_topic: "a5"
+        value_template: >-
+          {{ value_json.TMP | float(default=0) | round(1) }}
+        device_class: "temperature"
+        state_class: "measurement"
+        unit_of_measurement: "°C"
 
 # Below are mappings common to all EEPs
 common:
-   rssi:
-      - component: "sensor"
-        name: "rssi"
-        config:
-           state_topic: ""
-           value_template: "{{ value_json._RSSI_ }}"
-           unit_of_measurement: "dBm"
-           device_class: "signal_strength"
-           state_class: "measurement"
-           entity_category: "diagnostic"
-   date:
-      - component: "sensor"
-        name: "last_seen"
-        config:
-           state_topic: ""
-           value_template: >-
-             {{ value_json._DATE_|regex_replace(find='\..*$', replace='')|as_datetime()|as_local() }}
-           device_class: "timestamp"
-           entity_category: "diagnostic"
+  rssi:
+  - component: "sensor"
+    name: "rssi"
+    config:
+      state_topic: ""
+      value_template: "{{ value_json._RSSI_ }}"
+      unit_of_measurement: "dBm"
+      device_class: "signal_strength"
+      state_class: "measurement"
+      entity_category: "diagnostic"
+  date:
+  - component: "sensor"
+    name: "last_seen"
+    config:
+      state_topic: ""
+      value_template: >-
+        {{ value_json._DATE_|regex_replace(find='\..*$', replace='')|as_datetime()|as_local() }}
+      device_class: "timestamp"
+      entity_category: "diagnostic"
 
 # Mapping for system purpose (HA <-> enoceanmqtt configurations)
 system:
-   delete:
-      - system: "True"
-        component: "button"
-        name: "delete"
-        config:
-           command_topic: "__system"
-           payload_press: "delete"
-           icon: "mdi:delete"
-           entity_category: "config"
-   learn:
-      - system: "True"
-        component: "switch"
-        name: "ENOCEAN_LEARN"
-        config:
-           state_topic: "learn"
-           command_topic: "learn/req"
-           icon: "mdi:home-plus"
-           entity_category: "config"
+  delete:
+  - system: "True"
+    component: "button"
+    name: "delete"
+    config:
+      command_topic: "__system"
+      payload_press: "delete"
+      icon: "mdi:delete"
+      entity_category: "config"
+  learn:
+  - system: "True"
+    component: "switch"
+    name: "ENOCEAN_LEARN"
+    config:
+      state_topic: "learn"
+      command_topic: "learn/req"
+      icon: "mdi:home-plus"
+      entity_category: "config"


### PR DESCRIPTION
I ran ruamel.yaml over mappings to fix 
- #30 

```python
from ruamel.yaml import YAML
yaml = YAML()
yaml.width = 4096
yaml.preserve_quotes = True
with open("enoceanmqtt/overlays/homeassistant/mapping.yaml") as f:
    mapping = yaml.load(f)
 
with open("enoceanmqtt/overlays/homeassistant/mapping.yaml", mode="w") as f:
    yaml.dump(mapping, f)
```

May be you want to use [pre-commit](https://github.com/pre-commit/pre-commit) hook with [yamllint](https://github.com/adrienverge/yamllint/) to ensure consistent formating in the future.