### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ChristopheHD/HA_enoceanmqtt/security/code-scanning/1](https://github.com/ChristopheHD/HA_enoceanmqtt/security/code-scanning/1)

The best way to fix this issue is to explicitly specify a `permissions` block in the workflow file to restrict the privileges granted to the GITHUB_TOKEN. Since the workflow purely checks out code and runs linting steps, it only requires `contents: read` permissions, which allows actions to fetch (but not modify) repository content. This should be defined at the root level in `.github/workflows/lint.yml` immediately below the workflow's name, so that it applies to all jobs. No changes in the jobs or steps are necessary. All that’s needed is to add:

```yaml
permissions:
  contents: read
```

immediately after the `name` declaration at the top of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
