### PR TITLE
Fix F6 RPS telegram decoding failure in HA overlay

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/ha_communicator.py
+++ b/enoceanmqtt/overlays/homeassistant/ha_communicator.py
@@ -44,11 +44,18 @@ class HACommunicator(Communicator):
                     pass
 
                 # Set EEP-related device configuration
-                cur_sensor['command'] = devcfg.get('command')
-                cur_sensor['channel'] = devcfg.get('channel')
-                cur_sensor['log_learn'] = devcfg.get('log_learn')
-                cur_sensor['direction'] = devcfg.get('direction')
-                cur_sensor['answer'] = devcfg.get('answer')
+                # Only set fields if they have non-empty values to avoid passing empty strings
+                # to the EnOcean library which expects None for unset parameters
+                if devcfg.get('command'):
+                    cur_sensor['command'] = devcfg.get('command')
+                if devcfg.get('channel'):
+                    cur_sensor['channel'] = devcfg.get('channel')
+                if devcfg.get('log_learn'):
+                    cur_sensor['log_learn'] = devcfg.get('log_learn')
+                if devcfg.get('direction'):
+                    cur_sensor['direction'] = devcfg.get('direction')
+                if devcfg.get('answer'):
+                    cur_sensor['answer'] = devcfg.get('answer')
 
                 # Better to work with JSON in HA so force JSON usage
                 # Also force publish_rssi, publish_date and persistent


### PR DESCRIPTION
https://github.com/mak-gitdev/HA_enoceanmqtt/pull/173

When the HA overlay is enabled, F6 (RPS) devices like the PTM210 wall switch fail to decode with 'message not interpretable' errors, despite having correct mappings in mapping.yaml.

Root cause: The overlay unconditionally sets device configuration fields (command, channel, direction, etc.) from mapping.yaml, even when those fields contain empty strings. For F6-02-01, all these fields are set to empty string "".

The EnOcean library's parse_eep() method treats direction="" as an invalid parameter and fails to parse the telegram, returning no properties. This differs from direction=None, which correctly means 'no direction specified'.

Fix: Only set configuration fields if they have non-empty values. This ensures the EnOcean library receives None for unset parameters instead of empty strings.

Tested with:
- PTM210 DB (F6-02-01) wall switch: Messages now decode and publish
- ubiwizz relay (D2-01-01): Still works correctly (backwards compatible)

Fixes issue where F6-02-01 and similar RPS devices cannot be used with the HA overlay despite being listed as supported.