### PR TITLE
Update sensor configuration to check for non-empty values

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/ha_communicator.py
+++ b/enoceanmqtt/overlays/homeassistant/ha_communicator.py
@@ -50,11 +50,18 @@ class HACommunicator(Communicator):
                     pass
 
                 # Set EEP-related device configuration
-                cur_sensor['command']   = devcfg.get('command')
-                cur_sensor['channel']   = devcfg.get('channel')
-                cur_sensor['log_learn'] = devcfg.get('log_learn')
-                cur_sensor['direction'] = devcfg.get('direction')
-                cur_sensor['answer']    = devcfg.get('answer')
+                # Only set fields if they have non-empty values to avoid passing empty strings
+                # to the EnOcean library which expects None for unset parameters
+                if devcfg.get('command'):
+                    cur_sensor['command'] = devcfg.get('command')
+                if devcfg.get('channel'):
+                    cur_sensor['channel'] = devcfg.get('channel')
+                if devcfg.get('log_learn'):
+                    cur_sensor['log_learn'] = devcfg.get('log_learn')
+                if devcfg.get('direction'):
+                    cur_sensor['direction'] = devcfg.get('direction')
+                if devcfg.get('answer'):
+                    cur_sensor['answer'] = devcfg.get('answer')
                 cur_sensor['persistent']   = devcfg.get('persistent', "1")
 
                 # Better to work with JSON in HA so force JSON usage


### PR DESCRIPTION
Fix by @Hugo-HoB
Original PR : https://github.com/mak-gitdev/HA_enoceanmqtt/pull/173

Only set sensor fields if they have non-empty values to avoid passing empty strings to the EnOcean library.