### PR TITLE
🛡️ Sentinel: Fix DoS vulnerability in MQTT message processing

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-05 - DoS via Dictionary Modification During Iteration
+**Vulnerability:** A Denial of Service (DoS) vulnerability existed in `enoceanmqtt/communicator.py` where receiving a malformed JSON message over MQTT would cause a `RuntimeError` and crash the MQTT processing thread.
+**Learning:** Python prohibits modifying (adding or deleting items) a dictionary while iterating over it directly. This common programming pattern can become a security risk when the iteration is driven by external, untrusted input.
+**Prevention:** Always iterate over a copy of the dictionary keys using `list(dict_obj)` or similar when deletions might occur within the loop. This ensures the iterator remains valid even if the underlying dictionary is modified.

--- a/enoceanmqtt/communicator.py
+++ b/enoceanmqtt/communicator.py
@@ -254,7 +254,7 @@ class Communicator:
                     del mqtt_json_payload['send']
 
                 # Parse message content
-                for topic in mqtt_json_payload:
+                for topic in list(mqtt_json_payload):
                     try:
                         mqtt_json_payload[topic] = int(mqtt_json_payload[topic])
                     except ValueError:


### PR DESCRIPTION
Fixed a Denial of Service (DoS) vulnerability in the MQTT processing logic that caused a crash when handling malformed JSON payloads.

---
*PR created automatically by Jules for task [12823851930469536354](https://jules.google.com/task/12823851930469536354) started by @ChristopheHD*