### PR TITLE
CERV ERM-DAU-LV and ERM-DAU-277

### DIFF
--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -6037,6 +6037,7 @@ cerv:
         config:
           device_class: "power"
           state_topic: "a5"
+          off_delay: 130
           value_template: >-
             {% if value_json.PIRS >= 128 %}ON{% else %}OFF{% endif %}
   erm-dau-277: *erm-dau-lv

--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -6021,7 +6021,7 @@ nodon:
         - "1"
         - "2"
 
-cerv:
+etc-midwest:
   erm-dau-lv: &erm-dau-lv
     - rorg: "0xA5"
       func: "0x07"

--- a/enoceanmqtt/overlays/homeassistant/mapping.yaml
+++ b/enoceanmqtt/overlays/homeassistant/mapping.yaml
@@ -6021,6 +6021,26 @@ nodon:
         - "1"
         - "2"
 
+cerv:
+  erm-dau-lv: &erm-dau-lv
+    - rorg: "0xA5"
+      func: "0x07"
+      type: "0x01"
+      command: ""
+      channel: ""
+      log_learn: ""
+      direction: ""
+      answer: ""
+    entities:
+      - component: binary_sensor
+        name: "circuit"
+        config:
+          device_class: "power"
+          state_topic: "a5"
+          value_template: >-
+            {% if value_json.PIRS >= 128 %}ON{% else %}OFF{% endif %}
+  erm-dau-277: *erm-dau-lv
+
 # Below are mappings common to all EEPs
 common:
   rssi:


### PR DESCRIPTION
Following [this discussion](https://github.com/ChristopheHD/HA_enoceanmqtt-addon/issues/108#issuecomment-4322540327).
CERV manufacturer is building 2 active circuit transmitter (ACT). Those 2 ACT are non-certified EnOcean devices which relies on EEP A5-07-01 with an off_delay of 130s.